### PR TITLE
Add prerelease option to manual run of build action

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -11,6 +11,11 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      prerelease:
+        description: 'Generate a pre-release.'
+        required: false 
+        type: boolean
 
 jobs:
   build:
@@ -59,3 +64,25 @@ jobs:
         name: example-spec.pdf
         path: example-spec.pdf
         retention-days: 7
+    - name: Create Release
+      id: create_release
+      if: ${{ github.event.inputs.prerelease }}
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref_name }}
+        release_name: Release ${{ github.ref_name }}
+        draft: false
+        prerelease: true
+    - name: Upload Release Asset
+      id: upload-release-asset
+      if: ${{ github.event.inputs.prerelease }}
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./example-spec.pdf
+        asset_name: example-spec.pdf
+        asset_content_type: application/pdf


### PR DESCRIPTION
This adds the option to do a prerelease of the pdf build when that
worflow_dispatch is manually run. The name of the release is based of
the branch or tag name, so ideally one would run this with a branch name
of the style: v0.1.0.