### PR TITLE
readme: Link to relative file

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -9,15 +9,13 @@ provide your introduction to your repository.**
 = License
 
 This work is licensed under a Creative Commons Attribution 4.0 International License (CC-BY-4.0).
-See the https://github.com/riscv/docs-spec-template/blob/main/LICENSE[LICENSE] file for details.
+See the link:LICENSE[LICENSE] file for details.
 
 = Contributors
 
-Contributors to this specification are contained in the
-https://github.com/riscv/docs-spec-template/blob/main/contributors.adoc[contributors.adoc] file.
+Contributors to this specification are contained in the link:contributors.adoc[contributors] file.
 
-For instructions on how to contribute please see the
-https://github.com/riscv/docs-spec-template/blob/main/CONTRIBUTING.md[CONTRIBUTING] file.
+For instructions on how to contribute please see the link:CONTRIBUTING.md[CONTRIBUTING] file.
 
 = Dependencies
 


### PR DESCRIPTION
LICENSE, contributors.adoc and CONTRIBUTING.md are all local to this
repo, so let's link to their relative path in the readme.adoc file.

While we are here, omit the .adoc suffix in the the contributors.adoc
link display name.

Signed-off-by: Bin Meng <bmeng.cn@gmail.com>