### PR TITLE
Add Release Workflow

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -10,17 +10,35 @@ on:
   pull_request:
     branches:
       - main
+  workflow_call:
+    outputs:
+      name:
+        description: "The base name of the pdf file (without .pdf extensions)"
+        value: ${{ jobs.build.outputs.name }}
+      pdf-name:
+        description: "The name of the pdf file (with .pdf extensions)"
+        value: ${{ jobs.build.outputs.pdf-name }}
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     env:
+      NAME: example-spec
       APT_PACKAGES_FILE: ${{ github.workspace }}/dependencies/apt_packages.txt
       BUNDLE_GEMFILE: ${{ github.workspace }}/dependencies/Gemfile
       BUNDLE_BIN: ${{ github.workspace }}/bin
       NPM_PACKAGE_FOLDER: ${{ github.workspace }}/dependencies
+    outputs:
+      name: ${{ steps.step1.outputs.name }}
+      pdf-name: ${{ steps.step2.outputs.pdf-name }}
     steps:
+    - name: Set outputs.name
+      id: step1
+      run: echo "::set-output name=name::$NAME"
+    - name: Set outputs.pdf-name
+      id: step2
+      run: echo "::set-output name=pdf-name::$NAME.pdf"
     - name: Checkout repository
       uses: actions/checkout@v2
       with:
@@ -55,6 +73,6 @@ jobs:
     - name: Archive PDF result
       uses: actions/upload-artifact@v2
       with:
-        name: example-spec.pdf
-        path: example-spec.pdf
+        name: ${{ env.NAME }}.pdf
+        path: ${{ env.NAME }}.pdf
         retention-days: 7

--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -10,6 +10,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
   workflow_call:
     outputs:
       name:

--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -10,12 +10,6 @@ on:
   pull_request:
     branches:
       - main
-  workflow_dispatch:
-    inputs:
-      prerelease:
-        description: 'Generate a pre-release.'
-        required: false 
-        type: boolean
 
 jobs:
   build:
@@ -64,25 +58,3 @@ jobs:
         name: example-spec.pdf
         path: example-spec.pdf
         retention-days: 7
-    - name: Create Release
-      id: create_release
-      if: ${{ github.event.inputs.prerelease }}
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref_name }}
-        release_name: Release ${{ github.ref_name }}
-        draft: false
-        prerelease: true
-    - name: Upload Release Asset
-      id: upload-release-asset
-      if: ${{ github.event.inputs.prerelease }}
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./example-spec.pdf
-        asset_name: example-spec.pdf
-        asset_content_type: application/pdf

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -2,7 +2,7 @@
 #
 # NOTE: At this time it only runs manually.
 
-name: Create Vector Document Release
+name: Create Document Release
 
 on:
   workflow_dispatch:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,55 @@
+# This work flow includes source and PDF in Release.  It relies on the build-pdf workflow to create the PDF.
+#
+# NOTE: At this time it only runs manually.
+
+name: Create Vector Document Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version, e.g. X.Y.Z:'
+        required: true
+        type: string
+      prerelease:
+        description: 'Tag as a pre-release?'
+        required: false
+        type: boolean
+        default: true
+      draft:
+        description: 'Create release as a draft?'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  build:
+    uses: ./.github/workflows/build-pdf.yml
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: v${{ github.event.inputs.version }}
+        release_name: Release ${{ github.event.inputs.version }}
+        draft: ${{ github.event.inputs.draft }}
+        prerelease: ${{ github.event.inputs.prerelease }}
+    - name: Download Artifacts
+      uses: actions/download-artifact@v2
+      with:
+        name: ${{ needs.build.outputs.pdf-name }}
+    - name: Upload Release Asset
+      id: upload-release-asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path:  ${{ needs.build.outputs.pdf-name }}
+        asset_name:  ${{ needs.build.outputs.name }}_${{ github.event.inputs.version }}.pdf
+        asset_content_type: application/pdf


### PR DESCRIPTION
1. Remove the release steps from the current build-pdf workflow
2. Make the current build workflow reusable within the repo
3. Add a create-release workflow that uses the build-pdf workflow to build and then re-uses the code removed in the first step to adds all artifacts into a release.  It requests a version string (X.Y.Z), asks the release is a "pre-release" (defaults true), and asks if the release is a "draft release" (defaults false) to help customize the release.

All work flows can be dispatched manually.  The build-pdf workflow continues to build on push and pull_request as well as on workflow_call.

Signed-off-by: Jeff Scheel <jeff@riscv.org>