### PR TITLE
Fix asciidoctor-pdf theme attribute

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ OPTIONS := --trace \
            -a revremark=${REVMARK} \
            -a revdate=${DATE} \
            -a pdf-fontsdir=docs-resources/fonts \
-           -a pdf-style=docs-resources/themes/riscv-pdf.yml \
+           -a pdf-theme=docs-resources/themes/riscv-pdf.yml \
            --failure-level=ERROR
 REQUIRES := --require=asciidoctor-bibtex \
             --require=asciidoctor-diagram \


### PR DESCRIPTION
According to the Asciidoctor PDF 2.0 [changelog](https://docs.asciidoctor.org/pdf-converter/latest/upgrade-to-2/#theming-system-and-built-in-fonts), the `pdf-style` and `pdf-stylesdir` have been removed. The `pdf-theme` and `pdf-themesdir` are the replacements.

This is the title page of SPMP before change:
<img width="1125" alt="before" src="https://github.com/riscv/docs-spec-template/assets/22725367/353289d7-3722-420a-9752-71cd61d32351">

This is the title page of SPMP after change:
<img width="1050" alt="after" src="https://github.com/riscv/docs-spec-template/assets/22725367/34591b4f-61f8-4069-b1d6-0085e0a99323">