### PR TITLE
Only override VERSION and REVMARK for manual GitHub Actions builds

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -34,24 +34,28 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # Step 1: Checkout the repository
+      # Checkout the repository
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           submodules: recursive
 
-      # Step 2: Pull the latest RISC-V Docs container image
+      # Pull the latest RISC-V Docs container image
       - name: Pull Container
         run: docker pull riscvintl/riscv-docs-base-container-image:latest
 
-      # Step 3: Build Files
+      # Override VERSION and REVMARK for manual workflow dispatch
+      - name: Update environment variables
+        run: |
+          echo "VERSION=v${{ github.event.inputs.version }}" >> "$GITHUB_ENV"
+          echo "REVMARK=${{ github.event.inputs.revision_mark }}" >> "$GITHUB_ENV"
+        if: github.event_name == 'workflow_dispatch'
+
+      # Build Files
       - name: Build Files
         run: make
-        env:
-          VERSION: v${{ github.event.inputs.version }}
-          REVMARK: ${{ github.event.inputs.revision_mark }}
 
-      # Step 4: Upload the built PDF files as a single artifact
+      # Upload the built PDF files as a single artifact
       - name: Upload Build Artifacts
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
For non-manual builds the "env" argument to the "Build Files" step will set VERSION to "v" and REVMARK to the empty string which results in the version of the PDF being incorrect. To avoid this problem use a conditional step that updates $GITHUB_ENV for `workflow_dispatch` builds instead of setting the variables unconditionally.

This PR also removes the Step <N> prefix to all the comments since it does not add any explanatory value and makes it more difficult to update the workflow file.

See https://github.com/riscv/riscv-cheri/issues/72