### PR TITLE
Makefile: Add implicit SELinux labels when using podman

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,18 @@ VERSION ?= v0.0.0
 REVMARK ?= Draft
 DOCKER_IMG := riscvintl/riscv-docs-base-container-image:latest
 ifneq ($(SKIP_DOCKER),true)
-	DOCKER_CMD := docker run --rm -v ${PWD}:/build -w /build \
-	${DOCKER_IMG} \
-	/bin/sh -c
+	DOCKER_IS_PODMAN = \
+		$(shell ! docker -v 2>&1 | grep podman >/dev/null ; echo $$?)
+	ifeq "$(DOCKER_IS_PODMAN)" "1"
+		DOCKER_VOL_SUFFIX = :z
+	endif
+
+	DOCKER_CMD := \
+		docker run --rm \
+			-v ${PWD}:/build${DOCKER_VOL_SUFFIX} \
+			-w /build \
+			${DOCKER_IMG} \
+			/bin/sh -c
 	DOCKER_QUOTE := "
 endif
 


### PR DESCRIPTION
Podman is a Docker replacement, which is developed by RedHat and available on related Linux distributions (e.g. RHEL or Fedora).  Podman differs from Docker in several security-related aspects.  One of them is, that Podman requires poper SELinux labels on volume content mounted into a container. This difference to Docker results in the following error when building a document (the riscv-isa-manual in this example):

  Emulate Docker CLI using podman. Create /etc/containers/nodocker to quiet msg.
  /var/lib/gems/3.0.0/gems/asciidoctor-2.0.23/lib/asciidoctor/cli/options.rb:238:in `stat': Permission denied @ rb_file_s_stat - src/riscv-privileged.adoc (Errno::EACCES)
        from /var/lib/gems/3.0.0/gems/asciidoctor-2.0.23/lib/asciidoctor/cli/options.rb:238:in `block in parse!'
        from /var/lib/gems/3.0.0/gems/asciidoctor-2.0.23/lib/asciidoctor/cli/options.rb:236:in `each'
        from /var/lib/gems/3.0.0/gems/asciidoctor-2.0.23/lib/asciidoctor/cli/options.rb:236:in `parse!'
        from /var/lib/gems/3.0.0/gems/asciidoctor-pdf-2.3.18/bin/asciidoctor-pdf:40:in `<top (required)>'
        from /usr/local/bin/asciidoctor-pdf:25:in `load'
        from /usr/local/bin/asciidoctor-pdf:25:in `<main>'
  make[2]: *** [Makefile:92: build/riscv-privileged.pdf] Error 1

To address this, podman-run(1) recommends using the ':z' suffix to the volume mount.  This patch does so, if the docker command has been identified (reliably) to be emulated by Podman.

Tested on Fedora 40.

This change was also accepted and merged as part of the riscv-isa-manual repo, but the patch might be better suited to be included in this project.  See also https://github.com/riscv/riscv-isa-manual/pull/1598.