### PR TITLE
CONTRIBUTING: fix signed-off-by formatting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,9 +46,9 @@ By making a contribution to this project, I certify that:
 
 # DCO Sign-Off Methods
 The DCO necessitates the inclusion of a sign-off message in the following format for each commit within the pull request:
-
+```
 Signed-off-by: Stephano Cetola <scetola@linuxfoundation.org>
-
+```
 Please use your real name in the sign-off message.
 
 You can manually add the DCO text to your commit body or include either -s or --signoff in your standard Git commit commands. If you forget to incorporate the sign-off, you can also amend a previous commit with the sign-off by executing git commit --amend -s. If you have already pushed your changes to GitHub, you will need to force push your branch afterward using git push -f.


### PR DESCRIPTION
The current formatting looks like

> ![image](https://github.com/user-attachments/assets/decde0c2-dc9b-4978-b7a9-ebc0694837c0)

because text in <> is interpreted as mailto link.  Make it look like:

> ![image](https://github.com/user-attachments/assets/398c7553-a46c-4282-8e75-c985a8504e7b)

The copy icon is pointless, but in-line quote doesn't look as nice as block quote in this context.