### PR TITLE
Adopt ARC submission convention: milestone IDs + dated PDF naming

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -1,25 +1,27 @@
 ---
 name: Create Specification Document
 
-# The workflow is triggered by pull request, push to main, and manual dispatch.
+# The workflow is triggered by pull request, version tags, and manual dispatch.
 on:
   workflow_dispatch:
     inputs:
-      revision_mark:
-        description: 'Set revision mark to one of the choices:'
-        required: true
+      release_version:
+        description: 'Override version (e.g., v0.8.2). Milestone floors become official releases.'
+        required: false
+        type: string
+      target_phase:
+        description: 'Pick a milestone floor (recommended for official releases).'
+        required: false
         type: choice
+        default: auto-next
         options:
-          - Draft
+          - auto-next
+          - Draft and Development
+          - Developed
           - Stable
           - Frozen
+          - Ratification-Ready
           - Ratified
-        default: Draft
-      prerelease:
-        description: Tag as a pre-release?
-        required: false
-        type: boolean
-        default: true
       draft:
         description: Create release as a draft?
         required: false
@@ -27,8 +29,8 @@ on:
         default: false
   pull_request:
   push:
-    branches:
-      - main
+    tags:
+      - 'v*'
 
 jobs:
   build:
@@ -39,25 +41,56 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           submodules: recursive
-
-      - name: Get next version
-        uses: reecetech/version-increment@2024.4.4
-        id: version
-        with:
-          scheme: semver
-          increment: patch
 
       # Pull the latest RISC-V Docs container image
       - name: Pull Container
         run: docker pull riscvintl/riscv-docs-base-container-image:latest
 
-      # Override VERSION and REVMARK for manual workflow dispatch
-      - name: Update environment variables
+      # Set VERSION for all builds (manual overrides optional).
+      # Tag pushes use the exact tag; PR builds compute next patch.
+      # Manual builds support explicit version, milestone floor, or auto behavior.
+      - name: Set build version
         run: |
-          echo "VERSION=v${{ steps.version.outputs.version }}" >> "$GITHUB_ENV"
-          echo "REVMARK=${{ github.event.inputs.revision_mark }}" >> "$GITHUB_ENV"
-        if: github.event_name == 'workflow_dispatch'
+          set -euo pipefail
+          if [ -n "${{ github.event.inputs.release_version }}" ]; then
+            version="${{ github.event.inputs.release_version }}"
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.event.inputs.target_phase }}" != "auto-next" ]; then
+            version="$(./scripts/release-info.sh phase-floor-version "${{ github.event.inputs.target_phase }}")"
+          elif [ "${{ github.ref_type }}" = "tag" ]; then
+            version="${{ github.ref_name }}"
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            latest="$(./scripts/release-info.sh version)"
+            latest_phase="$(./scripts/release-info.sh phase "$latest")"
+            latest_floor="$(./scripts/release-info.sh phase-floor-version "$latest_phase")"
+            if [ "$latest" != "v0.0.0" ] && [ "$latest" != "$latest_floor" ]; then
+              # If current tag is between milestone floors, rebuild/re-release current latest tag.
+              version="$latest"
+            else
+              version="$(./scripts/release-info.sh next "$latest")"
+            fi
+          else
+            latest="$(./scripts/release-info.sh version)"
+            version="$(./scripts/release-info.sh next "$latest")"
+          fi
+          case "$version" in
+            v*) ;;
+            *) version="v$version" ;;
+          esac
+          echo "VERSION=$version" >> "$GITHUB_ENV"
+
+      - name: Classify release type
+        run: |
+          set -euo pipefail
+          case "${VERSION}" in
+            v0.6.0|v0.8.0|v0.9.0|v0.99.0|v1.0.0)
+              echo "OFFICIAL_RELEASE=true" >> "$GITHUB_ENV"
+              ;;
+            *)
+              echo "OFFICIAL_RELEASE=false" >> "$GITHUB_ENV"
+              ;;
+          esac
 
       # Build Files
       - name: Build Files
@@ -71,16 +104,54 @@ jobs:
           path: ${{ github.workspace }}/build/*.pdf
           retention-days: 30
 
-      # Create Release
-      - name: Create Release
+      # Create official release for version tag pushes
+      - name: Create Release (Tag Push, Official)
         uses: softprops/action-gh-release@v1
         with:
           files: ${{ github.workspace }}/build/*.pdf
-          tag_name: v${{ steps.version.outputs.version }}
-          name: Release ${{ steps.version.outputs.version }}
-          draft: ${{ github.event.inputs.draft }}
-          prerelease: ${{ github.event.inputs.prerelease }}
+          tag_name: ${{ env.VERSION }}
+          name: Release ${{ env.VERSION }}
+          draft: false
+          prerelease: false
         env:
-          GITHUB_TOKEN: ${{ secrets.GHTOKEN }}
-        if: github.event_name == 'workflow_dispatch'
-        # This condition ensures this step only runs for workflow_dispatch events.
+          GITHUB_TOKEN: ${{ secrets.GHTOKEN || secrets.GITHUB_TOKEN }}
+        if: github.event_name == 'push' && github.ref_type == 'tag' && env.OFFICIAL_RELEASE == 'true'
+
+      # Create prerelease for non-milestone version tag pushes
+      - name: Create Release (Tag Push, Pre-release)
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ${{ github.workspace }}/build/*.pdf
+          tag_name: ${{ env.VERSION }}
+          name: Release ${{ env.VERSION }}
+          draft: false
+          prerelease: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GHTOKEN || secrets.GITHUB_TOKEN }}
+        if: github.event_name == 'push' && github.ref_type == 'tag' && env.OFFICIAL_RELEASE != 'true'
+
+      # Create manual release for milestone versions
+      - name: Create Release (Manual, Official)
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ${{ github.workspace }}/build/*.pdf
+          tag_name: ${{ env.VERSION }}
+          name: Release ${{ env.VERSION }}
+          draft: ${{ github.event.inputs.draft }}
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GHTOKEN || secrets.GITHUB_TOKEN }}
+        if: github.event_name == 'workflow_dispatch' && env.OFFICIAL_RELEASE == 'true'
+
+      # Create manual prerelease for non-milestone versions
+      - name: Create Release (Manual, Pre-release)
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ${{ github.workspace }}/build/*.pdf
+          tag_name: ${{ env.VERSION }}
+          name: Release ${{ env.VERSION }}
+          draft: ${{ github.event.inputs.draft }}
+          prerelease: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GHTOKEN || secrets.GITHUB_TOKEN }}
+        if: github.event_name == 'workflow_dispatch' && env.OFFICIAL_RELEASE != 'true'

--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -16,12 +16,13 @@ on:
         default: auto-next
         options:
           - auto-next
-          - Draft and Development
-          - Developed
-          - Stable
-          - Frozen
-          - Ratification-Ready
-          - Ratified
+          - draft-and-development
+          - development-complete
+          - stabilized
+          - frozen
+          - ratification-ready
+          - publication
+          - ratified
       draft:
         description: Create release as a draft?
         required: false
@@ -83,8 +84,10 @@ jobs:
       - name: Classify release type
         run: |
           set -euo pipefail
+          # Milestone-gate tags get a non-prerelease GitHub Release.
+          # v0.99.1 is the entry into publication, so it is also considered official.
           case "${VERSION}" in
-            v0.6.0|v0.8.0|v0.9.0|v0.99.0|v1.0.0)
+            v0.6.0|v0.8.0|v0.9.0|v0.99.0|v0.99.1|v1.0.0)
               echo "OFFICIAL_RELEASE=true" >> "$GITHUB_ENV"
               ;;
             *)
@@ -92,9 +95,15 @@ jobs:
               ;;
           esac
 
-      # Build Files
+      # Build Files. VERSION and DATE are exported so the Makefile and
+      # release-info.sh produce ARC-compliant PDF names: <short>-v<ver>-<YYYYMMDD>.pdf
       - name: Build Files
-        run: make
+        run: |
+          set -euo pipefail
+          export VERSION="${VERSION}"
+          export DATE="$(date +%Y-%m-%d)"
+          echo "Building ${VERSION} (${DATE})"
+          make
 
       # Upload the built PDF files as a single artifact
       - name: Upload Build Artifacts

--- a/.github/workflows/version-bot.yml
+++ b/.github/workflows/version-bot.yml
@@ -16,12 +16,13 @@ on:
         default: auto-next
         options:
           - auto-next
-          - Draft and Development
-          - Developed
-          - Stable
-          - Frozen
-          - Ratification-Ready
-          - Ratified
+          - draft-and-development
+          - development-complete
+          - stabilized
+          - frozen
+          - ratification-ready
+          - publication
+          - ratified
       release_version:
         description: 'Explicit version override (e.g., v0.9.0). If set, target_phase is ignored.'
         required: false

--- a/.github/workflows/version-bot.yml
+++ b/.github/workflows/version-bot.yml
@@ -1,0 +1,169 @@
+---
+name: Version Bot
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/**'
+  workflow_dispatch:
+    inputs:
+      target_phase:
+        description: 'Force-jump to the milestone floor version for this phase'
+        required: false
+        type: choice
+        default: auto-next
+        options:
+          - auto-next
+          - Draft and Development
+          - Developed
+          - Stable
+          - Frozen
+          - Ratification-Ready
+          - Ratified
+      release_version:
+        description: 'Explicit version override (e.g., v0.9.0). If set, target_phase is ignored.'
+        required: false
+        type: string
+      allow_non_monotonic:
+        description: 'Allow jumps lower than the latest existing version tag'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  tag-version:
+    runs-on: ubuntu-latest
+    outputs:
+      previous_version: ${{ steps.version.outputs.previous_version }}
+      next_version: ${{ steps.version.outputs.next_version }}
+      previous_phase: ${{ steps.version.outputs.previous_phase }}
+      next_phase: ${{ steps.version.outputs.next_phase }}
+      milestone_transition: ${{ steps.version.outputs.milestone_transition }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Compute and tag next version
+        id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          TARGET_PHASE: ${{ github.event.inputs.target_phase }}
+          RELEASE_VERSION: ${{ github.event.inputs.release_version }}
+          ALLOW_NON_MONOTONIC: ${{ github.event.inputs.allow_non_monotonic }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          git fetch --tags --force
+
+          latest="$(git tag --list 'v*' --sort=-version:refname | head -n1 || true)"
+          latest="${latest:-v0.0.0}"
+
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            if [[ "$REF_NAME" != "main" ]]; then
+              echo "Manual version jump must run against main." >&2
+              exit 1
+            fi
+
+            if [[ -n "${RELEASE_VERSION:-}" ]]; then
+              next="$(./scripts/release-info.sh normalize "$RELEASE_VERSION")"
+            elif [[ -n "${TARGET_PHASE:-}" && "$TARGET_PHASE" != "auto-next" ]]; then
+              next="$(./scripts/release-info.sh phase-floor-version "$TARGET_PHASE")"
+            else
+              next="$(./scripts/release-info.sh next "$latest")"
+            fi
+          else
+            existing="$(git tag --points-at HEAD --list 'v*' | head -n1 || true)"
+            if [[ -n "$existing" ]]; then
+              next="$existing"
+            else
+              next="$(./scripts/release-info.sh next "$latest")"
+            fi
+          fi
+
+          if [[ "${ALLOW_NON_MONOTONIC:-false}" != "true" ]]; then
+            highest="$(printf '%s\n%s\n' "${latest#v}" "${next#v}" | sort -V | tail -n1)"
+            if [[ "$highest" != "${next#v}" ]]; then
+              echo "Refusing non-monotonic jump from $latest to $next. Set allow_non_monotonic=true to override." >&2
+              exit 1
+            fi
+          fi
+
+          if git rev-parse -q --verify "refs/tags/$next" >/dev/null; then
+            tag_sha="$(git rev-list -n1 "$next")"
+            head_sha="$(git rev-parse HEAD)"
+            if [[ "$tag_sha" != "$head_sha" ]]; then
+              echo "Tag $next already exists on another commit ($tag_sha)." >&2
+              exit 1
+            fi
+            echo "Tag $next already exists on HEAD; reusing."
+          else
+            git config user.name "riscv-gitbot"
+            git config user.email "actions@users.noreply.github.com"
+            git tag -a "$next" -m "Automated version tag for ${GITHUB_SHA}"
+            git push origin "$next"
+          fi
+
+          prev_phase="$(./scripts/release-info.sh phase "$latest")"
+          next_phase="$(./scripts/release-info.sh phase "$next")"
+
+          milestone_transition=false
+          if [[ "$prev_phase" != "$next_phase" ]]; then
+            milestone_transition=true
+          fi
+
+          echo "previous_version=$latest" >> "$GITHUB_OUTPUT"
+          echo "next_version=$next" >> "$GITHUB_OUTPUT"
+          echo "previous_phase=$prev_phase" >> "$GITHUB_OUTPUT"
+          echo "next_phase=$next_phase" >> "$GITHUB_OUTPUT"
+          echo "milestone_transition=$milestone_transition" >> "$GITHUB_OUTPUT"
+
+  milestone-pr:
+    runs-on: ubuntu-latest
+    needs: tag-version
+    if: needs.tag-version.outputs.milestone_transition == 'true'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Update specification state
+        run: |
+          set -euo pipefail
+          ./scripts/update-spec-state.sh "${{ needs.tag-version.outputs.next_version }}" "$(date +%Y-%m-%d)"
+
+      - name: Create milestone review PR
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "docs: milestone transition to ${{ needs.tag-version.outputs.next_phase }}"
+          branch: "gitbot/milestone-${{ needs.tag-version.outputs.next_version }}"
+          delete-branch: true
+          title: "Milestone reached: ${{ needs.tag-version.outputs.next_phase }} (${{ needs.tag-version.outputs.next_version }})"
+          body: |
+            This PR was opened automatically after a version milestone transition.
+
+            Previous version/state: `${{ needs.tag-version.outputs.previous_version }}` / `${{ needs.tag-version.outputs.previous_phase }}`
+            New version/state: `${{ needs.tag-version.outputs.next_version }}` / `${{ needs.tag-version.outputs.next_phase }}`
+
+            Please review and apply any governance/process updates required for this state transition.
+
+            Suggested maintainer checklist:
+            - Confirm the state transition is intentional.
+            - Confirm change-control policy for the new state is enforced.
+            - Confirm communication to contributors and implementers.
+          labels: |
+            milestone
+            spec-state
+          add-paths: |
+            SPEC_STATE.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /build/*
 /images/*
+.DS_Store
+**/.DS_Store

--- a/0001-Automate-Versioning.patch
+++ b/0001-Automate-Versioning.patch
@@ -1,0 +1,989 @@
+From 47bb11127d3715dbe3e3efeb354510da8bee353f Mon Sep 17 00:00:00 2001
+From: Rafael Sene <rafael@riscv.org>
+Date: Thu, 19 Feb 2026 12:53:46 -0300
+Subject: [PATCH] Automate Versioning
+
+Signed-off-by: Rafael Sene <rafael@riscv.org>
+---
+ .github/workflows/build-pdf.yml   | 139 ++++++++++----
+ .github/workflows/version-bot.yml | 169 ++++++++++++++++
+ CONTRIBUTING.md                   |  27 +++
+ Makefile                          |  12 +-
+ README.adoc                       |  65 +++++++
+ SPEC_STATE.md                     |  40 ++++
+ scripts/release-info.sh           | 307 ++++++++++++++++++++++++++++++
+ scripts/update-spec-state.sh      |  56 ++++++
+ src/spec-sample.adoc              |  15 +-
+ 9 files changed, 786 insertions(+), 44 deletions(-)
+ create mode 100644 .github/workflows/version-bot.yml
+ create mode 100644 SPEC_STATE.md
+ create mode 100755 scripts/release-info.sh
+ create mode 100755 scripts/update-spec-state.sh
+
+diff --git a/.github/workflows/build-pdf.yml b/.github/workflows/build-pdf.yml
+index 3264da7..6881a17 100644
+--- a/.github/workflows/build-pdf.yml
++++ b/.github/workflows/build-pdf.yml
+@@ -1,25 +1,27 @@
+ ---
+ name: Create Specification Document
+ 
+-# The workflow is triggered by pull request, push to main, and manual dispatch.
++# The workflow is triggered by pull request, version tags, and manual dispatch.
+ on:
+   workflow_dispatch:
+     inputs:
+-      revision_mark:
+-        description: 'Set revision mark to one of the choices:'
+-        required: true
++      release_version:
++        description: 'Override version (e.g., v0.8.2). Milestone floors become official releases.'
++        required: false
++        type: string
++      target_phase:
++        description: 'Pick a milestone floor (recommended for official releases).'
++        required: false
+         type: choice
++        default: auto-next
+         options:
+-          - Draft
++          - auto-next
++          - Draft and Development
++          - Developed
+           - Stable
+           - Frozen
++          - Ratification-Ready
+           - Ratified
+-        default: Draft
+-      prerelease:
+-        description: Tag as a pre-release?
+-        required: false
+-        type: boolean
+-        default: true
+       draft:
+         description: Create release as a draft?
+         required: false
+@@ -27,8 +29,8 @@ on:
+         default: false
+   pull_request:
+   push:
+-    branches:
+-      - main
++    tags:
++      - 'v*'
+ 
+ jobs:
+   build:
+@@ -39,25 +41,56 @@ jobs:
+       - name: Checkout repository
+         uses: actions/checkout@v4
+         with:
++          fetch-depth: 0
+           submodules: recursive
+ 
+-      - name: Get next version
+-        uses: reecetech/version-increment@2024.4.4
+-        id: version
+-        with:
+-          scheme: semver
+-          increment: patch
+-
+       # Pull the latest RISC-V Docs container image
+       - name: Pull Container
+         run: docker pull riscvintl/riscv-docs-base-container-image:latest
+ 
+-      # Override VERSION and REVMARK for manual workflow dispatch
+-      - name: Update environment variables
++      # Set VERSION for all builds (manual overrides optional).
++      # Tag pushes use the exact tag; PR builds compute next patch.
++      # Manual builds support explicit version, milestone floor, or auto behavior.
++      - name: Set build version
+         run: |
+-          echo "VERSION=v${{ steps.version.outputs.version }}" >> "$GITHUB_ENV"
+-          echo "REVMARK=${{ github.event.inputs.revision_mark }}" >> "$GITHUB_ENV"
+-        if: github.event_name == 'workflow_dispatch'
++          set -euo pipefail
++          if [ -n "${{ github.event.inputs.release_version }}" ]; then
++            version="${{ github.event.inputs.release_version }}"
++          elif [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.event.inputs.target_phase }}" != "auto-next" ]; then
++            version="$(./scripts/release-info.sh phase-floor-version "${{ github.event.inputs.target_phase }}")"
++          elif [ "${{ github.ref_type }}" = "tag" ]; then
++            version="${{ github.ref_name }}"
++          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
++            latest="$(./scripts/release-info.sh version)"
++            latest_phase="$(./scripts/release-info.sh phase "$latest")"
++            latest_floor="$(./scripts/release-info.sh phase-floor-version "$latest_phase")"
++            if [ "$latest" != "v0.0.0" ] && [ "$latest" != "$latest_floor" ]; then
++              # If current tag is between milestone floors, rebuild/re-release current latest tag.
++              version="$latest"
++            else
++              version="$(./scripts/release-info.sh next "$latest")"
++            fi
++          else
++            latest="$(./scripts/release-info.sh version)"
++            version="$(./scripts/release-info.sh next "$latest")"
++          fi
++          case "$version" in
++            v*) ;;
++            *) version="v$version" ;;
++          esac
++          echo "VERSION=$version" >> "$GITHUB_ENV"
++
++      - name: Classify release type
++        run: |
++          set -euo pipefail
++          case "${VERSION}" in
++            v0.6.0|v0.8.0|v0.9.0|v0.99.0|v1.0.0)
++              echo "OFFICIAL_RELEASE=true" >> "$GITHUB_ENV"
++              ;;
++            *)
++              echo "OFFICIAL_RELEASE=false" >> "$GITHUB_ENV"
++              ;;
++          esac
+ 
+       # Build Files
+       - name: Build Files
+@@ -71,16 +104,54 @@ jobs:
+           path: ${{ github.workspace }}/build/*.pdf
+           retention-days: 30
+ 
+-      # Create Release
+-      - name: Create Release
++      # Create official release for version tag pushes
++      - name: Create Release (Tag Push, Official)
+         uses: softprops/action-gh-release@v1
+         with:
+           files: ${{ github.workspace }}/build/*.pdf
+-          tag_name: v${{ steps.version.outputs.version }}
+-          name: Release ${{ steps.version.outputs.version }}
+-          draft: ${{ github.event.inputs.draft }}
+-          prerelease: ${{ github.event.inputs.prerelease }}
++          tag_name: ${{ env.VERSION }}
++          name: Release ${{ env.VERSION }}
++          draft: false
++          prerelease: false
+         env:
+-          GITHUB_TOKEN: ${{ secrets.GHTOKEN }}
+-        if: github.event_name == 'workflow_dispatch'
+-        # This condition ensures this step only runs for workflow_dispatch events.
++          GITHUB_TOKEN: ${{ secrets.GHTOKEN || secrets.GITHUB_TOKEN }}
++        if: github.event_name == 'push' && github.ref_type == 'tag' && env.OFFICIAL_RELEASE == 'true'
++
++      # Create prerelease for non-milestone version tag pushes
++      - name: Create Release (Tag Push, Pre-release)
++        uses: softprops/action-gh-release@v1
++        with:
++          files: ${{ github.workspace }}/build/*.pdf
++          tag_name: ${{ env.VERSION }}
++          name: Release ${{ env.VERSION }}
++          draft: false
++          prerelease: true
++        env:
++          GITHUB_TOKEN: ${{ secrets.GHTOKEN || secrets.GITHUB_TOKEN }}
++        if: github.event_name == 'push' && github.ref_type == 'tag' && env.OFFICIAL_RELEASE != 'true'
++
++      # Create manual release for milestone versions
++      - name: Create Release (Manual, Official)
++        uses: softprops/action-gh-release@v1
++        with:
++          files: ${{ github.workspace }}/build/*.pdf
++          tag_name: ${{ env.VERSION }}
++          name: Release ${{ env.VERSION }}
++          draft: ${{ github.event.inputs.draft }}
++          prerelease: false
++        env:
++          GITHUB_TOKEN: ${{ secrets.GHTOKEN || secrets.GITHUB_TOKEN }}
++        if: github.event_name == 'workflow_dispatch' && env.OFFICIAL_RELEASE == 'true'
++
++      # Create manual prerelease for non-milestone versions
++      - name: Create Release (Manual, Pre-release)
++        uses: softprops/action-gh-release@v1
++        with:
++          files: ${{ github.workspace }}/build/*.pdf
++          tag_name: ${{ env.VERSION }}
++          name: Release ${{ env.VERSION }}
++          draft: ${{ github.event.inputs.draft }}
++          prerelease: true
++        env:
++          GITHUB_TOKEN: ${{ secrets.GHTOKEN || secrets.GITHUB_TOKEN }}
++        if: github.event_name == 'workflow_dispatch' && env.OFFICIAL_RELEASE != 'true'
+diff --git a/.github/workflows/version-bot.yml b/.github/workflows/version-bot.yml
+new file mode 100644
+index 0000000..da23cf4
+--- /dev/null
++++ b/.github/workflows/version-bot.yml
+@@ -0,0 +1,169 @@
++---
++name: Version Bot
++
++on:
++  push:
++    branches:
++      - main
++    paths:
++      - 'src/**'
++  workflow_dispatch:
++    inputs:
++      target_phase:
++        description: 'Force-jump to the milestone floor version for this phase'
++        required: false
++        type: choice
++        default: auto-next
++        options:
++          - auto-next
++          - Draft and Development
++          - Developed
++          - Stable
++          - Frozen
++          - Ratification-Ready
++          - Ratified
++      release_version:
++        description: 'Explicit version override (e.g., v0.9.0). If set, target_phase is ignored.'
++        required: false
++        type: string
++      allow_non_monotonic:
++        description: 'Allow jumps lower than the latest existing version tag'
++        required: false
++        type: boolean
++        default: false
++
++permissions:
++  contents: write
++  pull-requests: write
++
++jobs:
++  tag-version:
++    runs-on: ubuntu-latest
++    outputs:
++      previous_version: ${{ steps.version.outputs.previous_version }}
++      next_version: ${{ steps.version.outputs.next_version }}
++      previous_phase: ${{ steps.version.outputs.previous_phase }}
++      next_phase: ${{ steps.version.outputs.next_phase }}
++      milestone_transition: ${{ steps.version.outputs.milestone_transition }}
++
++    steps:
++      - name: Checkout repository
++        uses: actions/checkout@v4
++        with:
++          fetch-depth: 0
++
++      - name: Compute and tag next version
++        id: version
++        env:
++          EVENT_NAME: ${{ github.event_name }}
++          TARGET_PHASE: ${{ github.event.inputs.target_phase }}
++          RELEASE_VERSION: ${{ github.event.inputs.release_version }}
++          ALLOW_NON_MONOTONIC: ${{ github.event.inputs.allow_non_monotonic }}
++          REF_NAME: ${{ github.ref_name }}
++        run: |
++          set -euo pipefail
++
++          git fetch --tags --force
++
++          latest="$(git tag --list 'v*' --sort=-version:refname | head -n1 || true)"
++          latest="${latest:-v0.0.0}"
++
++          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
++            if [[ "$REF_NAME" != "main" ]]; then
++              echo "Manual version jump must run against main." >&2
++              exit 1
++            fi
++
++            if [[ -n "${RELEASE_VERSION:-}" ]]; then
++              next="$(./scripts/release-info.sh normalize "$RELEASE_VERSION")"
++            elif [[ -n "${TARGET_PHASE:-}" && "$TARGET_PHASE" != "auto-next" ]]; then
++              next="$(./scripts/release-info.sh phase-floor-version "$TARGET_PHASE")"
++            else
++              next="$(./scripts/release-info.sh next "$latest")"
++            fi
++          else
++            existing="$(git tag --points-at HEAD --list 'v*' | head -n1 || true)"
++            if [[ -n "$existing" ]]; then
++              next="$existing"
++            else
++              next="$(./scripts/release-info.sh next "$latest")"
++            fi
++          fi
++
++          if [[ "${ALLOW_NON_MONOTONIC:-false}" != "true" ]]; then
++            highest="$(printf '%s\n%s\n' "${latest#v}" "${next#v}" | sort -V | tail -n1)"
++            if [[ "$highest" != "${next#v}" ]]; then
++              echo "Refusing non-monotonic jump from $latest to $next. Set allow_non_monotonic=true to override." >&2
++              exit 1
++            fi
++          fi
++
++          if git rev-parse -q --verify "refs/tags/$next" >/dev/null; then
++            tag_sha="$(git rev-list -n1 "$next")"
++            head_sha="$(git rev-parse HEAD)"
++            if [[ "$tag_sha" != "$head_sha" ]]; then
++              echo "Tag $next already exists on another commit ($tag_sha)." >&2
++              exit 1
++            fi
++            echo "Tag $next already exists on HEAD; reusing."
++          else
++            git config user.name "riscv-gitbot"
++            git config user.email "actions@users.noreply.github.com"
++            git tag -a "$next" -m "Automated version tag for ${GITHUB_SHA}"
++            git push origin "$next"
++          fi
++
++          prev_phase="$(./scripts/release-info.sh phase "$latest")"
++          next_phase="$(./scripts/release-info.sh phase "$next")"
++
++          milestone_transition=false
++          if [[ "$prev_phase" != "$next_phase" ]]; then
++            milestone_transition=true
++          fi
++
++          echo "previous_version=$latest" >> "$GITHUB_OUTPUT"
++          echo "next_version=$next" >> "$GITHUB_OUTPUT"
++          echo "previous_phase=$prev_phase" >> "$GITHUB_OUTPUT"
++          echo "next_phase=$next_phase" >> "$GITHUB_OUTPUT"
++          echo "milestone_transition=$milestone_transition" >> "$GITHUB_OUTPUT"
++
++  milestone-pr:
++    runs-on: ubuntu-latest
++    needs: tag-version
++    if: needs.tag-version.outputs.milestone_transition == 'true'
++
++    steps:
++      - name: Checkout repository
++        uses: actions/checkout@v4
++        with:
++          fetch-depth: 0
++
++      - name: Update specification state
++        run: |
++          set -euo pipefail
++          ./scripts/update-spec-state.sh "${{ needs.tag-version.outputs.next_version }}" "$(date +%Y-%m-%d)"
++
++      - name: Create milestone review PR
++        uses: peter-evans/create-pull-request@v6
++        with:
++          commit-message: "docs: milestone transition to ${{ needs.tag-version.outputs.next_phase }}"
++          branch: "gitbot/milestone-${{ needs.tag-version.outputs.next_version }}"
++          delete-branch: true
++          title: "Milestone reached: ${{ needs.tag-version.outputs.next_phase }} (${{ needs.tag-version.outputs.next_version }})"
++          body: |
++            This PR was opened automatically after a version milestone transition.
++
++            Previous version/state: `${{ needs.tag-version.outputs.previous_version }}` / `${{ needs.tag-version.outputs.previous_phase }}`
++            New version/state: `${{ needs.tag-version.outputs.next_version }}` / `${{ needs.tag-version.outputs.next_phase }}`
++
++            Please review and apply any governance/process updates required for this state transition.
++
++            Suggested maintainer checklist:
++            - Confirm the state transition is intentional.
++            - Confirm change-control policy for the new state is enforced.
++            - Confirm communication to contributors and implementers.
++          labels: |
++            milestone
++            spec-state
++          add-paths: |
++            SPEC_STATE.md
+diff --git a/CONTRIBUTING.md b/CONTRIBUTING.md
+index c925ae5..96c5124 100644
+--- a/CONTRIBUTING.md
++++ b/CONTRIBUTING.md
+@@ -2,6 +2,33 @@
+ 
+ As an open-source project, we appreciate and encourage community members to submit patches directly to the project. To maintain a well-organized development environment, we have established standards and methods for submitting changes. This document outlines the process for submitting patches to the project, ensuring that your contribution is swiftly incorporated into the codebase.
+ 
++# Version and State Automation
++
++Specification version/state metadata is managed by CI.
++
++- Pushes to `main` that modify `src/**` trigger the version bot workflow.
++- The bot creates the next patch tag (`vX.Y.Z`) from the latest existing `v*` tag.
++- Tag creation triggers the document build workflow, which sets `:revnumber:` and `:revdate:` during build.
++- Phase/state text (`:phase:`, `:phase_display:`, `:phase_notice:`, and `:revremark:`) is derived from the version via `scripts/release-info.sh`.
++- Pre-1.0 rollover rule: `v0.B.99` rolls to `v0.(B+1).0` for `B < 99` (for example `v0.0.99` -> `v0.1.0`).
++- Manual force-jump is available via `workflow_dispatch` in `.github/workflows/version-bot.yml`.
++- Use `target_phase` to jump to a milestone floor (for example `Frozen` -> `v0.9.0`).
++- Use `release_version` to set a specific version directly (this overrides `target_phase`).
++- Manual runs must target `main`.
++- Backward jumps are blocked by default; use `allow_non_monotonic=true` only when intentionally overriding this safety check.
++- Official release policy: only `v0.6.0`, `v0.8.0`, `v0.9.0`, `v0.99.0`, and `v1.0.0` are published as official (`prerelease=false`).
++- Every other version is published as a prerelease (`prerelease=true`).
++
++Milestone boundaries are:
++
++- `v0.6.x`: Developed
++- `v0.8.x`: Stable
++- `v0.9.x`: Frozen
++- `v0.99.x`: Ratification-Ready
++- `v1.0.0`: Ratified
++
++When a new version crosses a milestone boundary, CI opens a PR that updates `SPEC_STATE.md` for maintainer review.
++
+ # Licensing
+ 
+ Licensing is crucial for open-source projects, as it guarantees that the software remains available under the conditions specified by the author.
+diff --git a/Makefile b/Makefile
+index f6f174f..f9b82f2 100644
+--- a/Makefile
++++ b/Makefile
+@@ -16,8 +16,11 @@ DOCS := \
+ 	spec-sample.adoc
+ 
+ DATE ?= $(shell date +%Y-%m-%d)
+-VERSION ?= v0.0.0
+-REVMARK ?= Draft
++VERSION ?= $(shell ./scripts/release-info.sh version)
++PHASE ?= $(shell ./scripts/release-info.sh phase "$(VERSION)")
++PHASE_DISPLAY ?= $(shell ./scripts/release-info.sh display "$(VERSION)")
++PHASE_NOTICE ?= $(shell ./scripts/release-info.sh notice "$(VERSION)")
++REVMARK ?= $(shell ./scripts/release-info.sh revremark "$(VERSION)")
+ DOCKER_IMG := docker.io/riscvintl/riscv-docs-base-container-image:latest
+ DOCKER_BIN ?= docker
+ ifneq ($(SKIP_DOCKER),true)
+@@ -49,8 +52,11 @@ OPTIONS := --trace \
+            -a compress \
+            -a mathematical-format=svg \
+            -a revnumber=${VERSION} \
+-           -a revremark=${REVMARK} \
++           -a revremark='${REVMARK}' \
+            -a revdate=${DATE} \
++           -a phase='${PHASE}' \
++           -a phase_display='${PHASE_DISPLAY}' \
++           -a phase_notice='${PHASE_NOTICE}' \
+            -a pdf-fontsdir=docs-resources/fonts \
+            -a pdf-theme=docs-resources/themes/riscv-pdf.yml \
+            $(XTRA_ADOC_OPTS) \
+diff --git a/README.adoc b/README.adoc
+index d89c32d..710da91 100644
+--- a/README.adoc
++++ b/README.adoc
+@@ -81,6 +81,71 @@ To clean up the generated files, run:
+ make clean
+ ```
+ 
++== Automated Versioning and Milestones
++
++The repository includes CI automation for specification revision metadata and state transitions.
++
++=== Trigger for automated version bumps
++
++The version bot runs on pushes to `main` only when files under `src/**` change (the main specification content).
++
++=== End-to-end flow
++
++1. A commit that changes `src/**` is pushed to `main`.
++2. `.github/workflows/version-bot.yml` finds the latest `v*` tag and creates the next patch tag (`vX.Y.Z`) for that commit.
++3. The new tag triggers `.github/workflows/build-pdf.yml`.
++4. The build uses the tag as `:revnumber:` and sets `:revdate:` to the build date.
++5. `scripts/release-info.sh` derives phase (`:phase:`), display state (`:phase_display:`), warning text (`:phase_notice:`), and `:revremark:` from the version milestone.
++6. Tag-triggered builds publish GitHub Releases with the generated PDF artifacts.
++
++Version increment policy:
++
++* Normal step: increment patch (`vA.B.C` -> `vA.B.(C+1)`).
++* Pre-1.0 rollover: for `v0.B.C` where `B < 99`, `v0.B.99` rolls to `v0.(B+1).0`.
++* `v0.99.x` continues patch-only until maintainers intentionally ratify with `v1.0.0`.
++
++=== Milestone boundaries
++
++* `v0.6.x`: `Developed`
++* `v0.8.x`: `Stable`
++* `v0.9.x`: `Frozen`
++* `v0.99.x`: `Ratification-Ready`
++* `v1.0.0`: `Ratified`
++
++=== Official vs prerelease policy
++
++Only these exact versions are published as official releases (`prerelease=false`):
++
++* `v0.6.0`
++* `v0.8.0`
++* `v0.9.0`
++* `v0.99.0`
++* `v1.0.0`
++
++All other versions are published as prereleases (`prerelease=true`).
++
++=== Milestone PR behavior
++
++When a new tag crosses into a different phase than the previous tag, the bot opens a PR that updates `SPEC_STATE.md` for maintainer review. This PR is the checkpoint for governance/process updates required by the new phase.
++
++=== Manual build overrides
++
++`workflow_dispatch` for `.github/workflows/build-pdf.yml` supports:
++
++* `release_version` to force an explicit version.
++* `target_phase` to force a milestone floor (`Developed` -> `v0.6.0`, `Stable` -> `v0.8.0`, and so on).
++* With `target_phase=auto-next` (default), manual runs use the latest existing tag if that tag is between milestone floors; otherwise they compute the next patch.
++
++=== Manual version jumps
++
++`workflow_dispatch` for `.github/workflows/version-bot.yml` supports forced jumps:
++
++* Set `target_phase=Frozen` to force the milestone floor (`v0.9.0`).
++* Set `target_phase=Stable` to force `v0.8.0`, `Ratification-Ready` to force `v0.99.0`, and so on.
++* Set `release_version` (for example `v0.9.0`) to force an explicit version; this takes precedence over `target_phase`.
++* Manual jumps must run on `main`.
++* By default, backward jumps are blocked; set `allow_non_monotonic=true` only when intentionally overriding this safety check.
++
+ == Enabling pre-commit checks locally
+ 
+ The repository has some basic commit checks set up with https://pre-commit.com/[pre-commit] that will be enforced by the GitHub CI.
+diff --git a/SPEC_STATE.md b/SPEC_STATE.md
+new file mode 100644
+index 0000000..20efaaa
+--- /dev/null
++++ b/SPEC_STATE.md
+@@ -0,0 +1,40 @@
++# Specification State
++
++Current milestone: Draft and Development
++Current state: Draft and Development
++Current version: v0.0.0
++Last updated: 2026-02-19
++
++## Milestone Targets
++
++- v0.6.x Developed
++- v0.8.x Stable
++- v0.9.x Frozen
++- v0.99.x Ratification-Ready
++- v1.0.0 Ratified
++
++## State Definitions
++
++### Draft and Development
++
++Assume everything is subject to change. At this stage, ideas, structures, and content are still evolving. Feedback and iteration are encouraged as nothing is final, and adjustments may be frequent.
++
++### Developed
++
++Assume everything is subject to change. At this stage, ideas, structures, and content are still evolving. Feedback and iteration are encouraged as nothing is final, and adjustments may be frequent.
++
++### Stable
++
++Changes may still occur, but they should be limited in scope. The core structure and content are mostly settled, with only refinements or necessary adjustments expected. Any modifications should be carefully considered to maintain stability.
++
++### Frozen
++
++Changes are highly unlikely. A high threshold will be applied, and modifications will only be made in response to critical issues. Any other proposed changes should be addressed through a follow-on extension.
++
++### Ratification-Ready
++
++The specification is preparing for ratification. Only critical, ratification-blocking issues should be considered for change.
++
++### Ratified
++
++No changes are allowed. Any necessary or desired modifications must be addressed through a follow-on extension. Ratified extensions are never revised.
+diff --git a/scripts/release-info.sh b/scripts/release-info.sh
+new file mode 100755
+index 0000000..ffd3338
+--- /dev/null
++++ b/scripts/release-info.sh
+@@ -0,0 +1,307 @@
++#!/usr/bin/env bash
++set -euo pipefail
++
++DEFAULT_VERSION="v0.0.0"
++DEFAULT_PHASE="Draft and Development"
++SPEC_STATE_URL="http://riscv.org/spec-state"
++MAX_PATCH_BEFORE_MINOR_BUMP="${MAX_PATCH_BEFORE_MINOR_BUMP:-99}"
++
++usage() {
++  cat <<'USAGE'
++Usage: scripts/release-info.sh [version|normalize|next|phase|phase-floor-version|display|milestone|notice|revremark|all] [value]
++
++Outputs release metadata derived from VERSION/RELEASE_VERSION, git tags, or defaults.
++USAGE
++}
++
++normalize_version() {
++  local v="$1"
++  v="${v##*/}"
++  if [[ "$v" != v* ]]; then
++    v="v${v}"
++  fi
++  echo "$v"
++}
++
++base_version() {
++  local v="$1"
++  v="${v#v}"
++  v="${v%%+*}"
++  v="${v%%-*}"
++  echo "$v"
++}
++
++version_valid() {
++  local v
++  v="$(base_version "$1")"
++  [[ "$v" =~ ^[0-9]+(\.[0-9]+){1,2}$ ]]
++}
++
++parse_version() {
++  local v major minor patch
++  v="$(base_version "$1")"
++  IFS='.' read -r major minor patch <<<"$v"
++  patch="${patch:-0}"
++  echo "$major" "$minor" "$patch"
++}
++
++version_ge() {
++  local a1 b1 c1 a2 b2 c2
++  read -r a1 b1 c1 <<<"$(parse_version "$1")"
++  read -r a2 b2 c2 <<<"$(parse_version "$2")"
++  if (( a1 > a2 )); then
++    return 0
++  fi
++  if (( a1 == a2 && b1 > b2 )); then
++    return 0
++  fi
++  if (( a1 == a2 && b1 == b2 && c1 >= c2 )); then
++    return 0
++  fi
++  return 1
++}
++
++next_version() {
++  local major minor patch
++  read -r major minor patch <<<"$(parse_version "$1")"
++
++  # Progress pre-1.0 development by rolling patch to the next minor at .99.
++  if (( major == 0 && minor < 99 && patch >= MAX_PATCH_BEFORE_MINOR_BUMP )); then
++    minor=$((minor + 1))
++    patch=0
++  else
++    patch=$((patch + 1))
++  fi
++
++  printf 'v%s.%s.%s\n' "$major" "$minor" "$patch"
++}
++
++get_version() {
++  local v=""
++
++  if [[ -n "${VERSION:-}" ]]; then
++    v="$VERSION"
++  elif [[ -n "${RELEASE_VERSION:-}" ]]; then
++    v="$RELEASE_VERSION"
++  elif [[ -n "${GITHUB_REF_NAME:-}" ]]; then
++    if version_valid "$GITHUB_REF_NAME"; then
++      v="$GITHUB_REF_NAME"
++    fi
++  elif [[ -n "${GITHUB_REF:-}" ]]; then
++    local ref="${GITHUB_REF##*/}"
++    if version_valid "$ref"; then
++      v="$ref"
++    fi
++  fi
++
++  if [[ -z "$v" ]] && command -v git >/dev/null 2>&1; then
++    v="$(git tag --list 'v*' --sort=-version:refname | head -n1 || true)"
++  fi
++
++  if [[ -n "$v" ]] && version_valid "$v"; then
++    normalize_version "$v"
++    return 0
++  fi
++
++  echo "$DEFAULT_VERSION"
++}
++
++phase_for_version() {
++  local v="$1"
++
++  if ! version_valid "$v"; then
++    echo "$DEFAULT_PHASE"
++    return 0
++  fi
++
++  if version_ge "$v" "v1.0.0"; then
++    echo "Ratified"
++  elif version_ge "$v" "v0.99.0"; then
++    echo "Ratification-Ready"
++  elif version_ge "$v" "v0.9.0"; then
++    echo "Frozen"
++  elif version_ge "$v" "v0.8.0"; then
++    echo "Stable"
++  elif version_ge "$v" "v0.6.0"; then
++    echo "Developed"
++  else
++    echo "Draft and Development"
++  fi
++}
++
++milestone_for_phase() {
++  case "$1" in
++    "Developed")
++      echo "v0.6.x Developed"
++      ;;
++    "Stable")
++      echo "v0.8.x Stable"
++      ;;
++    "Frozen")
++      echo "v0.9.x Frozen"
++      ;;
++    "Ratification-Ready")
++      echo "v0.99.x Ratification-Ready"
++      ;;
++    "Ratified")
++      echo "v1.0.0 Ratified"
++      ;;
++    *)
++      echo "Draft and Development"
++      ;;
++  esac
++}
++
++phase_floor_version() {
++  case "$1" in
++    "Draft and Development")
++      echo "v0.0.1"
++      ;;
++    "Developed")
++      echo "v0.6.0"
++      ;;
++    "Stable")
++      echo "v0.8.0"
++      ;;
++    "Frozen")
++      echo "v0.9.0"
++      ;;
++    "Ratification-Ready")
++      echo "v0.99.0"
++      ;;
++    "Ratified")
++      echo "v1.0.0"
++      ;;
++    *)
++      echo "Unknown phase '$1'" >&2
++      return 2
++      ;;
++  esac
++}
++
++notice_for_phase() {
++  case "$1" in
++    "Draft and Development"|"Developed")
++      echo "Assume everything is subject to change. At this stage, ideas, structures, and content are still evolving. Feedback and iteration are encouraged as nothing is final, and adjustments may be frequent."
++      ;;
++    "Stable")
++      echo "Changes may still occur, but they should be limited in scope. The core structure and content are mostly settled, with only refinements or necessary adjustments expected. Any modifications should be carefully considered to maintain stability."
++      ;;
++    "Frozen")
++      echo "Changes are highly unlikely. A high threshold will be applied, and modifications will only be made in response to critical issues. Any other proposed changes should be addressed through a follow-on extension."
++      ;;
++    "Ratification-Ready")
++      echo "The specification is preparing for ratification. Only critical, ratification-blocking issues should be considered for change."
++      ;;
++    "Ratified")
++      echo "No changes are allowed. Any necessary or desired modifications must be addressed through a follow-on extension. Ratified extensions are never revised."
++      ;;
++    *)
++      echo "Assume everything is subject to change until a formal milestone is reached."
++      ;;
++  esac
++}
++
++revremark_for_phase() {
++  case "$1" in
++    "Draft and Development"|"Developed")
++      echo "This document is under development. Expect potential changes. Visit ${SPEC_STATE_URL} for further details."
++      ;;
++    "Stable")
++      echo "This document is in stable state. Only limited-scope changes are expected. Visit ${SPEC_STATE_URL} for further details."
++      ;;
++    "Frozen")
++      echo "This document is in frozen state. Only critical fixes should be considered. Visit ${SPEC_STATE_URL} for further details."
++      ;;
++    "Ratification-Ready")
++      echo "This document is ratification-ready. Changes are highly restricted pending ratification. Visit ${SPEC_STATE_URL} for further details."
++      ;;
++    "Ratified")
++      echo "This document is ratified. No changes are allowed; use a follow-on extension for updates. Visit ${SPEC_STATE_URL} for further details."
++      ;;
++    *)
++      echo "This document is under development. Visit ${SPEC_STATE_URL} for further details."
++      ;;
++  esac
++}
++
++phase_from_input() {
++  local input="${1:-}"
++  if [[ -z "$input" ]]; then
++    phase_for_version "$(get_version)"
++  elif version_valid "$input"; then
++    phase_for_version "$input"
++  else
++    echo "$input"
++  fi
++}
++
++command="${1:-all}"
++value="${2:-}"
++
++case "$command" in
++  version)
++    get_version
++    ;;
++  normalize)
++    if [[ -z "$value" ]]; then
++      echo "normalize requires a version value" >&2
++      exit 2
++    fi
++    if ! version_valid "$value"; then
++      echo "invalid version: $value" >&2
++      exit 2
++    fi
++    normalize_version "$value"
++    ;;
++  next)
++    if [[ -z "$value" ]]; then
++      value="$(get_version)"
++    fi
++    next_version "$value"
++    ;;
++  phase)
++    if [[ -z "$value" ]]; then
++      value="$(get_version)"
++    fi
++    phase_for_version "$value"
++    ;;
++  phase-floor-version)
++    if [[ -z "$value" ]]; then
++      value="$(phase_for_version "$(get_version)")"
++    fi
++    phase_floor_version "$value"
++    ;;
++  display)
++    if [[ -z "$value" ]]; then
++      value="$(get_version)"
++    fi
++    phase_for_version "$value"
++    ;;
++  milestone)
++    phase="$(phase_from_input "$value")"
++    milestone_for_phase "$phase"
++    ;;
++  notice)
++    phase="$(phase_from_input "$value")"
++    notice_for_phase "$phase"
++    ;;
++  revremark)
++    phase="$(phase_from_input "$value")"
++    revremark_for_phase "$phase"
++    ;;
++  all|"")
++    version="$(get_version)"
++    phase="$(phase_for_version "$version")"
++    display="$phase"
++    milestone="$(milestone_for_phase "$phase")"
++    notice="$(notice_for_phase "$phase")"
++    revremark="$(revremark_for_phase "$phase")"
++    printf 'VERSION=%s\nPHASE=%s\nPHASE_DISPLAY=%s\nMILESTONE=%s\nPHASE_NOTICE=%s\nREVMARK=%s\n' \
++      "$version" "$phase" "$display" "$milestone" "$notice" "$revremark"
++    ;;
++  *)
++    usage
++    exit 2
++    ;;
++esac
+diff --git a/scripts/update-spec-state.sh b/scripts/update-spec-state.sh
+new file mode 100755
+index 0000000..e76c1f7
+--- /dev/null
++++ b/scripts/update-spec-state.sh
+@@ -0,0 +1,56 @@
++#!/usr/bin/env bash
++set -euo pipefail
++
++if [[ $# -lt 1 ]]; then
++  echo "Usage: scripts/update-spec-state.sh <version> [date]" >&2
++  exit 2
++fi
++
++version="$1"
++updated_on="${2:-$(date +%Y-%m-%d)}"
++
++phase="$(./scripts/release-info.sh phase "$version")"
++milestone="$(./scripts/release-info.sh milestone "$version")"
++
++cat > SPEC_STATE.md <<STATE
++# Specification State
++
++Current milestone: ${milestone}
++Current state: ${phase}
++Current version: ${version}
++Last updated: ${updated_on}
++
++## Milestone Targets
++
++- v0.6.x Developed
++- v0.8.x Stable
++- v0.9.x Frozen
++- v0.99.x Ratification-Ready
++- v1.0.0 Ratified
++
++## State Definitions
++
++### Draft and Development
++
++Assume everything is subject to change. At this stage, ideas, structures, and content are still evolving. Feedback and iteration are encouraged as nothing is final, and adjustments may be frequent.
++
++### Developed
++
++Assume everything is subject to change. At this stage, ideas, structures, and content are still evolving. Feedback and iteration are encouraged as nothing is final, and adjustments may be frequent.
++
++### Stable
++
++Changes may still occur, but they should be limited in scope. The core structure and content are mostly settled, with only refinements or necessary adjustments expected. Any modifications should be carefully considered to maintain stability.
++
++### Frozen
++
++Changes are highly unlikely. A high threshold will be applied, and modifications will only be made in response to critical issues. Any other proposed changes should be addressed through a follow-on extension.
++
++### Ratification-Ready
++
++The specification is preparing for ratification. Only critical, ratification-blocking issues should be considered for change.
++
++### Ratified
++
++No changes are allowed. Any necessary or desired modifications must be addressed through a follow-on extension. Ratified extensions are never revised.
++STATE
+diff --git a/src/spec-sample.adoc b/src/spec-sample.adoc
+index d2a978d..b99b2e7 100644
+--- a/src/spec-sample.adoc
++++ b/src/spec-sample.adoc
+@@ -1,11 +1,14 @@
+ = RISC-V Example Specification Document (Zexmpl)
+ Authors: Author 1, Author 2
+ include::../docs-resources/global-config.adoc[]
++ifndef::revnumber[:revnumber: v0.0.0]
++ifndef::revdate[:revdate: 1/2023]
++ifndef::phase[:phase: Draft and Development]
++ifndef::phase_display[:phase_display: {phase}]
++ifndef::phase_notice[:phase_notice: Assume everything is subject to change. At this stage, ideas, structures, and content are still evolving. Feedback and iteration are encouraged as nothing is final, and adjustments may be frequent.]
++ifndef::revremark[:revremark: This document is under development. Expect potential changes. Visit http://riscv.org/spec-state for further details.]
+ :docgroup: RISC-V Task Group
+ :description: RISC-V Example Specification Document (Zexmpl)
+-:revdate: 1/2023
+-:revnumber: 1.0
+-:revremark: This document is under development. Expect potential changes. Visit http://riscv.org/spec-state for further details.
+ :revinfo:
+ :preface-title: Preamble
+ :colophon:
+@@ -51,11 +54,9 @@ list-of::table[hide_empty_section=true, enhanced_rendering=true]
+ list-of::listing[hide_empty_section=true, enhanced_rendering=true]
+ 
+ [WARNING]
+-.This document is in the link:http://riscv.org/spec-state[Development state]
++.This document is in the link:http://riscv.org/spec-state[{phase_display} state]
+ ====
+-Expect potential changes. This draft specification is likely to evolve before
+-it is accepted as a standard. Implementations based on this draft
+-may not conform to the future standard.
++{phase_notice}
+ ====
+ 
+ [preface]
+-- 
+2.50.1 (Apple Git-155)
+

--- a/ARC_SUBMISSION.md
+++ b/ARC_SUBMISSION.md
@@ -1,0 +1,221 @@
+# ARC Submission Requirements for ISA and non-ISA Specifications
+
+**Audience:** Maintainers, editors, and chairs of any specification repository
+under `github.com/riscv/*` (ISA) and `github.com/riscv-non-isa/*` (non-ISA)
+that submits work to the Architecture Review Committee (ARC) for review.
+
+**Effective:** Immediately. ARC will **reject submissions that do not meet
+these requirements**.
+
+---
+
+## 0. Notice from ARC (verbatim)
+
+> ARC has been having issues with submitted specifications not being in the
+> form of a clearly versioned file that has been released in github with a
+> unique and monotonic version tag. Future review requests of specifications
+> will be rejected unless the specifications are of the following form:
+>
+> * Link to a tag on github, which contains the compiled pdf.
+>
+> * The compiled pdf file name has to contain a version string matching the
+>   tag and also a date stamp (e.g, `Zifoo-v0.8-20260520.pdf`).
+>
+> * The title page of the document must match the above information.
+
+The rest of this document operationalizes that notice — specifying the
+exact tag/filename/title-page conventions, the version→milestone mapping
+that goes on the title page, and how the `docs-spec-template` toolchain
+produces compliant artifacts automatically.
+
+---
+
+## 1. Why this exists
+
+ARC has been receiving spec submissions in inconsistent forms — uncompiled
+sources, draft PDFs without identifiers, or files whose name/title/version do
+not match. This makes review unreproducible: ARC cannot be sure two reviewers
+are looking at the same artifact, and the reviewed artifact cannot be cited
+later. The rules below make every reviewable artifact uniquely identifiable.
+
+## 2. What ARC requires
+
+Every specification submitted to ARC for review MUST be presented as:
+
+1. **A link to a Git tag on GitHub** in the spec's canonical repository
+   (`riscv/<repo>` or `riscv-non-isa/<repo>`). The tag MUST point at the exact
+   commit the PDF was built from.
+
+2. **The compiled PDF MUST be published with the tag** — either as an asset on
+   a GitHub Release attached to that tag, or committed at the tagged commit.
+   A bare tag with no PDF is not a valid submission.
+
+3. **The PDF filename MUST contain**:
+   - the spec short name,
+   - the version string matching the tag, and
+   - a date stamp in `YYYYMMDD` form.
+
+   Pattern: `<spec-short-name>-v<X.Y.Z>-<YYYYMMDD>.pdf`
+
+4. **The PDF title page MUST display the same information** — spec name,
+   version string, milestone ID, and date — and they MUST match the filename
+   and the tag.
+
+## 3. Conventions
+
+### 3.1 Version → Milestone mapping
+
+Tags use **`vMAJOR.MINOR.PATCH`** semver form. The `MAJOR.MINOR` pair encodes
+the milestone; `PATCH` is the revision within that milestone band. The
+milestone ID is the single canonical label that identifies what state the
+document is in.
+
+| Milestone ID            | Tag at milestone gate | Revisions within phase     |
+| ----------------------- | --------------------- | -------------------------- |
+| `development-complete`  | `v0.6.0`              | `v0.6.1`, `v0.6.2`, …      |
+| `stabilized`            | `v0.8.0`              | `v0.8.1`, `v0.8.2`, …      |
+| `frozen`                | `v0.9.0`              | `v0.9.1`, `v0.9.2`, …      |
+| `ratification-ready`    | `v0.99.0`             | (no patches; single tag)   |
+| `publication`           | `v0.99.1`             | `v0.99.2`, `v0.99.3`, …    |
+| `ratified`              | `v1.0.0`              | `v1.0.1`, … (errata)       |
+
+**Tags MUST be monotonically increasing.** Never delete or rewrite a
+published tag — create a new one.
+
+A revision tag carries the milestone label of the **most recent gate
+passed**. Example: `v0.8.3` is still labeled `stabilized` until the spec is
+re-tagged at `v0.9.0` (`frozen`).
+
+### 3.2 PDF filename
+
+```
+<spec-short-name>-v<MAJOR>.<MINOR>.<PATCH>-<YYYYMMDD>.pdf
+```
+
+Worked examples — one per milestone:
+
+| Filename                                | Milestone            |
+| --------------------------------------- | -------------------- |
+| `Zifoo-v0.6.0-20260520.pdf`             | development-complete |
+| `Zifoo-v0.8.0-20260612.pdf`             | stabilized           |
+| `RHTI-v0.9.0-20260408.pdf`              | frozen               |
+| `Server-Platform-v0.99.0-20260415.pdf`  | ratification-ready   |
+| `Server-Platform-v0.99.1-20260520.pdf`  | publication          |
+| `Zifoo-v1.0.0-20260901.pdf`             | ratified             |
+
+Use the **short name** registered for the spec, not the long title. Use
+hyphens, not spaces.
+
+### 3.3 Title page
+
+The first page of the PDF MUST show, prominently:
+
+- Spec long title and short name
+- Full semver version string matching the tag and filename (e.g. `v0.8.0`)
+- Date in human-readable form matching the `YYYYMMDD` in the filename
+- **Milestone label**, the title-case display form of one of the canonical
+  milestone IDs:
+
+  | Canonical ID (filenames, scripts) | Display label (title page) |
+  | --------------------------------- | -------------------------- |
+  | `draft-and-development`           | Draft and Development      |
+  | `development-complete`            | Development Complete       |
+  | `stabilized`                      | Stabilized                 |
+  | `frozen`                          | Frozen                     |
+  | `ratification-ready`              | Ratification-Ready         |
+  | `publication`                     | Publication                |
+  | `ratified`                        | Ratified                   |
+
+The canonical ID is what scripts, filenames, and CI consumers reference.
+The display label is what humans see on the title page.
+
+Repos derived from `docs-spec-template` get this layout automatically:
+
+- **Page 1 (title page):** title, authors, and a single revision line of the
+  form `Version vX.Y.Z, YYYY-MM-DD: <Milestone display label>` — for
+  example `Version v1.0.0, 2026-05-24: Ratified`. This is asciidoctor-pdf's
+  default rendering of `revnumber, revdate: revremark`, with `revremark`
+  set to the title-case display label.
+
+- **Page 2 (Document State preface):** a single `Note:` paragraph
+  containing the phase notice — e.g.,
+  > **Note:** This document is ratified. No changes are allowed; use a
+  > follow-on extension for updates.
+
+- **Page 3 onward:** TOC, list-of prefaces, and body content.
+
+The `Document State` preface is created in the spec source with:
+
+```adoc
+[preface]
+== Document State
+*Note:* {phase_notice}
+
+toc::[]
+```
+
+`{phase_notice}` is set automatically by the Makefile via
+`scripts/release-info.sh notice <version>`.
+
+## 4. How to comply
+
+### 4.1 Release flow (recommended)
+
+1. Freeze the source at the commit you intend to submit.
+2. Run the `Create Specification Document` GitHub Action with
+   `target_phase` set to the milestone you're cutting (e.g. `stabilized`)
+   — OR push a tag of the form `v0.8.0`.
+3. The workflow builds the PDF with `VERSION` and `DATE` plumbed through
+   the Makefile, produces `build/<short>-v<X.Y.Z>-<YYYYMMDD>.pdf`, creates
+   a GitHub Release, and attaches the PDF.
+4. Verify the title page shows the version, milestone ID, and date.
+5. Use the **GitHub Release URL** when scheduling the ARC slot.
+
+### 4.2 Building locally
+
+```bash
+make VERSION=v0.8.0 DATE=2026-06-12
+ls build/
+# → <short>-v0.8.0-20260612.pdf
+```
+
+The `arc-rename` target in the Makefile produces the ARC-compliant filename
+on every build — there is no separate "ARC build" target; every PDF this
+repo emits is ARC-compliant by construction.
+
+### 4.3 Multi-document repos
+
+If your repo builds more than one specification, list each in `DOCS` and
+the `arc-rename` target renames each PDF with its own basename. If two
+docs in one repo are submitted to ARC independently, ensure their
+basenames are the ARC short names.
+
+## 5. Pre-submission checklist
+
+Before requesting an ARC review slot, confirm:
+
+- [ ] Tag `v<X>.<Y>.<Z>` is pushed to the canonical repo
+- [ ] Tag is on a commit that builds reproducibly
+- [ ] PDF is published (release asset preferred) with filename
+      `<short>-v<X>.<Y>.<Z>-<YYYYMMDD>.pdf`
+- [ ] PDF title page shows the same short name, version, milestone ID, and
+      date
+- [ ] The version and date in filename, tag, title page, and milestone ID
+      are mutually consistent (no `v0.85` filename with a `frozen`
+      milestone, etc.)
+- [ ] Tag version is monotonically greater than the previous tag
+
+ARC reviewers reference the **tag link** (or release URL), not a draft or
+branch. Submissions that don't satisfy the checklist will be rejected and
+rescheduled.
+
+## 6. Migration
+
+If your repo was forked from `docs-spec-template` before this policy was
+introduced, see `MIGRATION.md` in this template repo for a step-by-step
+checklist to bring the toolchain in line.
+
+## 7. Where to ask for help
+
+- Policy questions: `help@riscv.org`
+- Tooling / build issues: open an issue against `riscv/docs-spec-template`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,33 @@
 
 As an open-source project, we appreciate and encourage community members to submit patches directly to the project. To maintain a well-organized development environment, we have established standards and methods for submitting changes. This document outlines the process for submitting patches to the project, ensuring that your contribution is swiftly incorporated into the codebase.
 
+# Version and State Automation
+
+Specification version/state metadata is managed by CI.
+
+- Pushes to `main` that modify `src/**` trigger the version bot workflow.
+- The bot creates the next patch tag (`vX.Y.Z`) from the latest existing `v*` tag.
+- Tag creation triggers the document build workflow, which sets `:revnumber:` and `:revdate:` during build.
+- Phase/state text (`:phase:`, `:phase_display:`, `:phase_notice:`, and `:revremark:`) is derived from the version via `scripts/release-info.sh`.
+- Pre-1.0 rollover rule: `v0.B.99` rolls to `v0.(B+1).0` for `B < 99` (for example `v0.0.99` -> `v0.1.0`).
+- Manual force-jump is available via `workflow_dispatch` in `.github/workflows/version-bot.yml`.
+- Use `target_phase` to jump to a milestone floor (for example `Frozen` -> `v0.9.0`).
+- Use `release_version` to set a specific version directly (this overrides `target_phase`).
+- Manual runs must target `main`.
+- Backward jumps are blocked by default; use `allow_non_monotonic=true` only when intentionally overriding this safety check.
+- Official release policy: only `v0.6.0`, `v0.8.0`, `v0.9.0`, `v0.99.0`, and `v1.0.0` are published as official (`prerelease=false`).
+- Every other version is published as a prerelease (`prerelease=true`).
+
+Milestone boundaries are:
+
+- `v0.6.x`: Developed
+- `v0.8.x`: Stable
+- `v0.9.x`: Frozen
+- `v0.99.x`: Ratification-Ready
+- `v1.0.0`: Ratified
+
+When a new version crosses a milestone boundary, CI opens a PR that updates `SPEC_STATE.md` for maintainer review.
+
 # Licensing
 
 Licensing is crucial for open-source projects, as it guarantees that the software remains available under the conditions specified by the author.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,269 @@
+# Migration Guide — ARC Submission Compliance
+
+**Who this is for:** Maintainers of any RISC-V specification repository under
+`github.com/riscv/*` (ISA) or `github.com/riscv-non-isa/*` (non-ISA) that was
+forked from `docs-spec-template` or shares its toolchain (Makefile +
+`scripts/release-info.sh` + `.github/workflows/build-pdf.yml`).
+
+**Why this exists:** ARC will reject specification submissions that do not
+emit a PDF named `<short>-v<X.Y.Z>-<YYYYMMDD>.pdf` whose title page matches.
+The upstream `docs-spec-template` now produces that format automatically,
+and uses six canonical milestone IDs (`development-complete`, `stabilized`,
+`frozen`, `ratification-ready`, `publication`, `ratified`). Downstream repos
+need to pick up these changes — usually by syncing the same five files.
+
+See `ARC_SUBMISSION.md` in this template repo for the policy itself.
+
+## Pre-flight
+
+- [ ] Read `ARC_SUBMISSION.md` to understand what your repo must emit.
+- [ ] Confirm your repo's spec short name (e.g. `Zifoo`, `Server-Platform`,
+      `RHTI`). This is the `<spec-short>` that appears in PDF filenames.
+- [ ] Check the latest tag in your repo (`git tag --list 'v*' --sort=-version:refname | head -1`).
+      Your next tag MUST be monotonically greater.
+- [ ] **Do NOT rewrite or delete existing tags.** The policy is
+      forward-looking; old artifacts stay as-is.
+
+## Step 1 — Sync `scripts/release-info.sh`
+
+Replace your script with the upstream version, or apply the following changes:
+
+- [ ] Phase IDs switched from `Developed`/`Stable`/`Frozen`/`Ratification-Ready`/`Ratified`
+      to the canonical (lowercase, hyphenated) IDs
+      `development-complete`/`stabilized`/`frozen`/`ratification-ready`/`publication`/`ratified`.
+- [ ] New `publication` band added at `v0.99.1+` (between `ratification-ready`
+      at `v0.99.0` and `ratified` at `v1.0.0`).
+- [ ] New helper `phase_display_for_phase` returns the title-case display
+      label (e.g. `Stabilized`, `Ratification-Ready`) used on the title page.
+- [ ] `revremark_for_phase` is now a thin wrapper that returns just the
+      display label (e.g. `"Ratified"`), so asciidoctor-pdf renders
+      `Version vX.Y.Z, YYYY-MM-DD: <Label>` on the title page.
+- [ ] `display` CLI command returns the display label (title-case), not the
+      canonical ID.
+- [ ] `notice_for_phase`, `phase_floor_version`, `milestone_for_phase` all
+      keyed on the new canonical IDs.
+- [ ] `DEFAULT_PHASE` is `draft-and-development` (was `"Draft and Development"`).
+
+Smoke test:
+```bash
+for v in v0.5.0 v0.6.0 v0.7.3 v0.8.0 v0.9.0 v0.99.0 v0.99.1 v1.0.0; do
+  printf "%-10s phase=%-22s display=%s\n" "$v" \
+    "$(./scripts/release-info.sh phase $v)" \
+    "$(./scripts/release-info.sh display $v)"
+done
+```
+Expected:
+```
+v0.5.0     phase=draft-and-development  display=Draft and Development
+v0.6.0     phase=development-complete   display=Development Complete
+v0.7.3     phase=development-complete   display=Development Complete
+v0.8.0     phase=stabilized             display=Stabilized
+v0.9.0     phase=frozen                 display=Frozen
+v0.99.0    phase=ratification-ready     display=Ratification-Ready
+v0.99.1    phase=publication            display=Publication
+v1.0.0     phase=ratified               display=Ratified
+```
+
+## Step 2 — Update `Makefile`
+
+- [ ] Set `SPEC_SHORT` near the top of the file. If your `DOCS` list has one
+      `.adoc`, you can use:
+      ```make
+      SPEC_SHORT ?= $(basename $(firstword $(DOCS)))
+      ```
+      For repos where the spec short name differs from the .adoc basename,
+      hard-code it:
+      ```make
+      SPEC_SHORT := Zifoo
+      ```
+- [ ] Add these variables:
+      ```make
+      DATE_STAMP := $(subst -,,$(DATE))
+      VERSION_NUM := $(patsubst v%,%,$(VERSION))
+      MILESTONE_ID ?= $(PHASE)
+      ```
+- [ ] Add `milestone_id` and `spec_short` attributes to the AsciiDoctor
+      `OPTIONS` list:
+      ```make
+      -a milestone_id='${MILESTONE_ID}' \
+      -a spec_short='${SPEC_SHORT}' \
+      ```
+- [ ] Add the `arc-rename` target and make `build-docs` depend on it:
+      ```make
+      .PHONY: ... arc-rename
+
+      build-docs: $(DOCS_PDF) $(DOCS_HTML) arc-rename
+
+      arc-rename: $(DOCS_PDF)
+      	@for pdf in $(DOCS_PDF); do \
+      		base=$$(basename $$pdf .pdf); \
+      		dest="$$base-v$(VERSION_NUM)-$(DATE_STAMP).pdf"; \
+      		if [ -f build/$$pdf ]; then \
+      			mv build/$$pdf build/$$dest; \
+      			echo "ARC submission PDF: build/$$dest"; \
+      		fi; \
+      	done
+      ```
+
+Smoke test (no Docker required):
+```bash
+make -n SKIP_DOCKER=true VERSION=v0.8.0 DATE=2026-06-12 | grep -E "(asciidoctor|ARC|dest=)"
+```
+Should show `dest="<short>-v0.8.0-20260612.pdf"`.
+
+## Step 3 — Update `.github/workflows/build-pdf.yml`
+
+- [ ] Replace `target_phase` enum values with the canonical IDs:
+      ```yaml
+      options:
+        - auto-next
+        - draft-and-development
+        - development-complete
+        - stabilized
+        - frozen
+        - ratification-ready
+        - publication
+        - ratified
+      ```
+- [ ] Add `v0.99.1` to the `OFFICIAL_RELEASE` case statement so entry into
+      publication is treated as an official release:
+      ```yaml
+      case "${VERSION}" in
+        v0.6.0|v0.8.0|v0.9.0|v0.99.0|v0.99.1|v1.0.0)
+          echo "OFFICIAL_RELEASE=true" >> "$GITHUB_ENV" ;;
+        *)
+          echo "OFFICIAL_RELEASE=false" >> "$GITHUB_ENV" ;;
+      esac
+      ```
+- [ ] Export `VERSION` and `DATE` in the build step so the Makefile picks
+      them up:
+      ```yaml
+      - name: Build Files
+        run: |
+          set -euo pipefail
+          export VERSION="${VERSION}"
+          export DATE="$(date +%Y-%m-%d)"
+          echo "Building ${VERSION} (${DATE})"
+          make
+      ```
+- [ ] **No change needed** to upload globs — `path: build/*.pdf` and
+      `files: build/*.pdf` will pick up the ARC-named PDF automatically.
+
+## Step 4 — Update `.github/workflows/version-bot.yml` (if present)
+
+- [ ] Replace `target_phase` enum values with the canonical IDs (same list
+      as Step 3).
+- [ ] No other changes required — the bot calls `release-info.sh` which
+      already emits the new labels.
+
+## Step 5 — Update your spec source `.adoc` files
+
+- [ ] Update the `ifndef::phase[]` default to `draft-and-development`:
+      ```adoc
+      ifndef::phase[:phase: draft-and-development]
+      ```
+- [ ] Add defaults for the new attributes:
+      ```adoc
+      ifndef::milestone_id[:milestone_id: {phase}]
+      ifndef::spec_short[:spec_short: <your-spec-short>]
+      ```
+- [ ] Switch the TOC to a macro placement so we can position it manually
+      (so the Document State preface lands on page 2, TOC on page 3):
+      ```adoc
+      :toc: macro
+      :toclevels: 4
+      :toc-title: Table of Contents
+      ```
+      (Replaces `:toc: left` or `:toc: auto`.)
+- [ ] Add a `Document State` preface as the FIRST preface, immediately
+      followed by the explicit `toc::[]` placement. Remove any previous
+      `WARNING`/`NOTE` admonition that surfaced the phase notice — its job
+      is now done by this block:
+      ```adoc
+      [preface]
+      == Document State
+      *Note:* {phase_notice}
+
+      toc::[]
+
+      [preface]
+      == List of figures
+      list-of::image[hide_empty_section=true, enhanced_rendering=true]
+
+      ...   // other prefaces follow as before
+      ```
+- [ ] **Do not** add a `WARNING` admonition for the phase notice anywhere
+      else. The title-page revision line shows the milestone label
+      automatically (via the new `revremark`); the `Document State` preface
+      shows the full notice. Anything more is duplication.
+
+## Step 6 — Verify
+
+Build locally and inspect the output:
+```bash
+make VERSION=v0.8.0 DATE=2026-06-12
+ls build/
+```
+You should see exactly one PDF named `<short>-v0.8.0-20260612.pdf`. Open it
+and confirm:
+
+- [ ] **Filename** contains short name, `v0.8.0`, and `20260612`.
+- [ ] **Page 1 (title page)** ends with the line:
+      `Version v0.8.0, 2026-06-12: Stabilized`.
+- [ ] **Page 2** is a preface titled `Document State` whose only content is
+      a `Note:` paragraph with the phase notice.
+- [ ] **Page 3** is the Table of Contents (and includes `Document State`
+      as its first entry).
+- [ ] Page 4+ are the list-of-X prefaces and body content.
+
+## Step 7 — Cut your next release
+
+When you're ready to advance to the next milestone:
+
+- [ ] Open the `Create Specification Document` workflow → `Run workflow`.
+- [ ] Pick the target milestone from `target_phase` (or leave on `auto-next`
+      for an intermediate patch tag).
+- [ ] Confirm the resulting release has a single PDF whose name matches the
+      ARC convention.
+- [ ] Use the **GitHub Release URL** (not a branch or commit URL) in the ARC
+      review request.
+
+## Step 8 — Confirm with ARC (one-time)
+
+- [ ] Reply on the ARC mailing list / Jira ticket that your repo is compliant
+      with `ARC_SUBMISSION.md`, citing the URL of your first ARC-conformant
+      release.
+
+## Common gotchas
+
+- **Existing pre-`v0.6.0` tags:** the script labels them `draft-and-development`,
+  which is fine. No action needed.
+- **Repos that don't use this template's Makefile:** you still need to emit a
+  PDF named per §3.2 of `ARC_SUBMISSION.md` and a title page per §3.3.
+  Adopting the template Makefile is the easiest way; otherwise replicate the
+  naming logic in whatever build system you use.
+- **Multi-document repos:** the `arc-rename` target loops over every PDF in
+  `$(DOCS_PDF)`, so each gets renamed with its own basename + version + date.
+  If two docs in one repo need to be ARC-submitted independently, the
+  `SPEC_SHORT` heuristic uses the .adoc basename — verify that's the short
+  name ARC expects.
+- **GitHub Actions caching:** if you cache `build/` between runs, clear the
+  cache once so the old `spec-sample.pdf` doesn't ghost the renamed output.
+- **Don't rewrite tags.** Push a new monotonically-greater tag if you need to
+  reissue.
+- **`:toc: macro` requires explicit placement.** If you switch from
+  `:toc: left` to `:toc: macro` and forget the `toc::[]` line, the PDF will
+  build without a Table of Contents. Always pair the attribute change with
+  the macro placement in Step 5.
+- **No theme/submodule edits required.** The new layout is achieved entirely
+  through the spec `.adoc`, the Makefile, and `release-info.sh`. Do not
+  modify `docs-resources/themes/riscv-pdf.yml` — earlier drafts of this
+  guide suggested editing the theme; the final approach does not.
+- **Pre-existing in-body phase admonitions** (e.g. a `WARNING` block keyed
+  on `{phase_display}`) MUST be removed when you add the `Document State`
+  preface, or the phase notice will appear twice.
+
+## Questions / help
+
+`help@riscv.org` for ARC policy questions. Open an issue against
+`riscv/docs-spec-template` for tooling/migration issues.

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ PHASE_DISPLAY ?= $(shell ./scripts/release-info.sh display "$(VERSION)")
 PHASE_NOTICE ?= $(shell ./scripts/release-info.sh notice "$(VERSION)")
 REVMARK ?= $(shell ./scripts/release-info.sh revremark "$(VERSION)")
 MILESTONE_ID ?= $(PHASE)
-DOCKER_IMG := docker.io/riscvintl/ghcr.io/riscv/riscv-docs-base-container-image:latest
+DOCKER_IMG := riscvintl/riscv-docs-base-container-image:latest
 DOCKER_BIN ?= docker
 ifneq ($(SKIP_DOCKER),true)
 	DOCKER_IS_PODMAN = \

--- a/Makefile
+++ b/Makefile
@@ -15,12 +15,19 @@
 DOCS := \
 	spec-sample.adoc
 
+# Spec short name used in ARC-compliant PDF filenames.
+# Override in derived repos: e.g. SPEC_SHORT := Zifoo
+SPEC_SHORT ?= $(basename $(firstword $(DOCS)))
+
 DATE ?= $(shell date +%Y-%m-%d)
+DATE_STAMP := $(subst -,,$(DATE))
 VERSION ?= $(shell ./scripts/release-info.sh version)
+VERSION_NUM := $(patsubst v%,%,$(VERSION))
 PHASE ?= $(shell ./scripts/release-info.sh phase "$(VERSION)")
 PHASE_DISPLAY ?= $(shell ./scripts/release-info.sh display "$(VERSION)")
 PHASE_NOTICE ?= $(shell ./scripts/release-info.sh notice "$(VERSION)")
 REVMARK ?= $(shell ./scripts/release-info.sh revremark "$(VERSION)")
+MILESTONE_ID ?= $(PHASE)
 DOCKER_IMG := docker.io/riscvintl/riscv-docs-base-container-image:latest
 DOCKER_BIN ?= docker
 ifneq ($(SKIP_DOCKER),true)
@@ -57,6 +64,8 @@ OPTIONS := --trace \
            -a phase='${PHASE}' \
            -a phase_display='${PHASE_DISPLAY}' \
            -a phase_notice='${PHASE_NOTICE}' \
+           -a milestone_id='${MILESTONE_ID}' \
+           -a spec_short='${SPEC_SHORT}' \
            -a pdf-fontsdir=docs-resources/fonts \
            -a pdf-theme=docs-resources/themes/riscv-pdf.yml \
            $(XTRA_ADOC_OPTS) \
@@ -67,11 +76,24 @@ REQUIRES := --require=asciidoctor-bibtex \
 			--require=asciidoctor-lists \
             --require=asciidoctor-mathematical
 
-.PHONY: all build clean build-container build-no-container build-docs
+.PHONY: all build clean build-container build-no-container build-docs arc-rename
 
 all: build
 
-build-docs: $(DOCS_PDF) $(DOCS_HTML)
+# After AsciiDoctor produces build/<basename>.pdf, rename each PDF to the
+# ARC-compliant form <basename>-v<version>-<YYYYMMDD>.pdf so every build
+# (local or CI) emits a uniquely identifiable artifact.
+build-docs: $(DOCS_PDF) $(DOCS_HTML) arc-rename
+
+arc-rename: $(DOCS_PDF)
+	@for pdf in $(DOCS_PDF); do \
+		base=$$(basename $$pdf .pdf); \
+		dest="$$base-v$(VERSION_NUM)-$(DATE_STAMP).pdf"; \
+		if [ -f build/$$pdf ]; then \
+			mv build/$$pdf build/$$dest; \
+			echo "ARC submission PDF: build/$$dest"; \
+		fi; \
+	done
 
 vpath %.adoc $(SRC_DIR)
 

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,11 @@ DOCS := \
 	spec-sample.adoc
 
 DATE ?= $(shell date +%Y-%m-%d)
-VERSION ?= v0.0.0
-REVMARK ?= Draft
+VERSION ?= $(shell ./scripts/release-info.sh version)
+PHASE ?= $(shell ./scripts/release-info.sh phase "$(VERSION)")
+PHASE_DISPLAY ?= $(shell ./scripts/release-info.sh display "$(VERSION)")
+PHASE_NOTICE ?= $(shell ./scripts/release-info.sh notice "$(VERSION)")
+REVMARK ?= $(shell ./scripts/release-info.sh revremark "$(VERSION)")
 DOCKER_IMG := docker.io/riscvintl/riscv-docs-base-container-image:latest
 DOCKER_BIN ?= docker
 ifneq ($(SKIP_DOCKER),true)
@@ -49,8 +52,11 @@ OPTIONS := --trace \
            -a compress \
            -a mathematical-format=svg \
            -a revnumber=${VERSION} \
-           -a revremark=${REVMARK} \
+           -a revremark='${REVMARK}' \
            -a revdate=${DATE} \
+           -a phase='${PHASE}' \
+           -a phase_display='${PHASE_DISPLAY}' \
+           -a phase_notice='${PHASE_NOTICE}' \
            -a pdf-fontsdir=docs-resources/fonts \
            -a pdf-theme=docs-resources/themes/riscv-pdf.yml \
            $(XTRA_ADOC_OPTS) \

--- a/README.adoc
+++ b/README.adoc
@@ -81,6 +81,71 @@ To clean up the generated files, run:
 make clean
 ```
 
+== Automated Versioning and Milestones
+
+The repository includes CI automation for specification revision metadata and state transitions.
+
+=== Trigger for automated version bumps
+
+The version bot runs on pushes to `main` only when files under `src/**` change (the main specification content).
+
+=== End-to-end flow
+
+1. A commit that changes `src/**` is pushed to `main`.
+2. `.github/workflows/version-bot.yml` finds the latest `v*` tag and creates the next patch tag (`vX.Y.Z`) for that commit.
+3. The new tag triggers `.github/workflows/build-pdf.yml`.
+4. The build uses the tag as `:revnumber:` and sets `:revdate:` to the build date.
+5. `scripts/release-info.sh` derives phase (`:phase:`), display state (`:phase_display:`), warning text (`:phase_notice:`), and `:revremark:` from the version milestone.
+6. Tag-triggered builds publish GitHub Releases with the generated PDF artifacts.
+
+Version increment policy:
+
+* Normal step: increment patch (`vA.B.C` -> `vA.B.(C+1)`).
+* Pre-1.0 rollover: for `v0.B.C` where `B < 99`, `v0.B.99` rolls to `v0.(B+1).0`.
+* `v0.99.x` continues patch-only until maintainers intentionally ratify with `v1.0.0`.
+
+=== Milestone boundaries
+
+* `v0.6.x`: `Developed`
+* `v0.8.x`: `Stable`
+* `v0.9.x`: `Frozen`
+* `v0.99.x`: `Ratification-Ready`
+* `v1.0.0`: `Ratified`
+
+=== Official vs prerelease policy
+
+Only these exact versions are published as official releases (`prerelease=false`):
+
+* `v0.6.0`
+* `v0.8.0`
+* `v0.9.0`
+* `v0.99.0`
+* `v1.0.0`
+
+All other versions are published as prereleases (`prerelease=true`).
+
+=== Milestone PR behavior
+
+When a new tag crosses into a different phase than the previous tag, the bot opens a PR that updates `SPEC_STATE.md` for maintainer review. This PR is the checkpoint for governance/process updates required by the new phase.
+
+=== Manual build overrides
+
+`workflow_dispatch` for `.github/workflows/build-pdf.yml` supports:
+
+* `release_version` to force an explicit version.
+* `target_phase` to force a milestone floor (`Developed` -> `v0.6.0`, `Stable` -> `v0.8.0`, and so on).
+* With `target_phase=auto-next` (default), manual runs use the latest existing tag if that tag is between milestone floors; otherwise they compute the next patch.
+
+=== Manual version jumps
+
+`workflow_dispatch` for `.github/workflows/version-bot.yml` supports forced jumps:
+
+* Set `target_phase=Frozen` to force the milestone floor (`v0.9.0`).
+* Set `target_phase=Stable` to force `v0.8.0`, `Ratification-Ready` to force `v0.99.0`, and so on.
+* Set `release_version` (for example `v0.9.0`) to force an explicit version; this takes precedence over `target_phase`.
+* Manual jumps must run on `main`.
+* By default, backward jumps are blocked; set `allow_non_monotonic=true` only when intentionally overriding this safety check.
+
 == Enabling pre-commit checks locally
 
 The repository has some basic commit checks set up with https://pre-commit.com/[pre-commit] that will be enforced by the GitHub CI.

--- a/README.adoc
+++ b/README.adoc
@@ -4,6 +4,13 @@ This repository serves as a template for creating GitHub repositories within the
 
 NOTE: If you are viewing this in a specification repository, kindly update the title for this section and provide an introduction relevant to your repository.
 
+[IMPORTANT]
+====
+**ARC submissions:** Specifications submitted to the Architecture Review Committee (ARC) must follow the conventions in link:ARC_SUBMISSION.md[ARC_SUBMISSION.md] — versioned GitHub tag, PDF named `<short>-v<X.Y.Z>-<YYYYMMDD>.pdf`, and a title page that matches. The Makefile and CI workflows in this template produce ARC-compliant artifacts on every build by default.
+
+**Migrating an existing repo?** See link:MIGRATION.md[MIGRATION.md] for the step-by-step checklist to bring a downstream fork in line with the current toolchain.
+====
+
 == License
 
 This work is licensed under a Creative Commons Attribution 4.0 International License (CC-BY-4.0). For details, see the link:LICENSE[LICENSE] file.

--- a/SPEC_STATE.md
+++ b/SPEC_STATE.md
@@ -1,0 +1,40 @@
+# Specification State
+
+Current milestone: Draft and Development
+Current state: Draft and Development
+Current version: v0.0.0
+Last updated: 2026-02-19
+
+## Milestone Targets
+
+- v0.6.x Developed
+- v0.8.x Stable
+- v0.9.x Frozen
+- v0.99.x Ratification-Ready
+- v1.0.0 Ratified
+
+## State Definitions
+
+### Draft and Development
+
+Assume everything is subject to change. At this stage, ideas, structures, and content are still evolving. Feedback and iteration are encouraged as nothing is final, and adjustments may be frequent.
+
+### Developed
+
+Assume everything is subject to change. At this stage, ideas, structures, and content are still evolving. Feedback and iteration are encouraged as nothing is final, and adjustments may be frequent.
+
+### Stable
+
+Changes may still occur, but they should be limited in scope. The core structure and content are mostly settled, with only refinements or necessary adjustments expected. Any modifications should be carefully considered to maintain stability.
+
+### Frozen
+
+Changes are highly unlikely. A high threshold will be applied, and modifications will only be made in response to critical issues. Any other proposed changes should be addressed through a follow-on extension.
+
+### Ratification-Ready
+
+The specification is preparing for ratification. Only critical, ratification-blocking issues should be considered for change.
+
+### Ratified
+
+No changes are allowed. Any necessary or desired modifications must be addressed through a follow-on extension. Ratified extensions are never revised.

--- a/scripts/release-info.sh
+++ b/scripts/release-info.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 DEFAULT_VERSION="v0.0.0"
-DEFAULT_PHASE="Draft and Development"
+DEFAULT_PHASE="draft-and-development"
 SPEC_STATE_URL="http://riscv.org/spec-state"
 MAX_PATCH_BEFORE_MINOR_BUMP="${MAX_PATCH_BEFORE_MINOR_BUMP:-99}"
 
@@ -106,6 +106,22 @@ get_version() {
   echo "$DEFAULT_VERSION"
 }
 
+phase_display_for_phase() {
+  # Title-case display label rendered on the PDF title page and in the body
+  # NOTE admonition. The canonical (lowercase, hyphenated) ID stays usable for
+  # filenames, scripts, and machine-readable consumers; this is the human form.
+  case "$1" in
+    "draft-and-development") echo "Draft and Development" ;;
+    "development-complete")  echo "Development Complete"  ;;
+    "stabilized")            echo "Stabilized"            ;;
+    "frozen")                echo "Frozen"                ;;
+    "ratification-ready")    echo "Ratification-Ready"    ;;
+    "publication")           echo "Publication"           ;;
+    "ratified")              echo "Ratified"              ;;
+    *)                       echo "Draft"                 ;;
+  esac
+}
+
 phase_for_version() {
   local v="$1"
 
@@ -114,62 +130,72 @@ phase_for_version() {
     return 0
   fi
 
+  # Canonical RISC-V P&P milestone IDs. The version number encodes the
+  # milestone gate; see ARC_SUBMISSION.md.
   if version_ge "$v" "v1.0.0"; then
-    echo "Ratified"
+    echo "ratified"
+  elif version_ge "$v" "v0.99.1"; then
+    echo "publication"
   elif version_ge "$v" "v0.99.0"; then
-    echo "Ratification-Ready"
+    echo "ratification-ready"
   elif version_ge "$v" "v0.9.0"; then
-    echo "Frozen"
+    echo "frozen"
   elif version_ge "$v" "v0.8.0"; then
-    echo "Stable"
+    echo "stabilized"
   elif version_ge "$v" "v0.6.0"; then
-    echo "Developed"
+    echo "development-complete"
   else
-    echo "Draft and Development"
+    echo "draft-and-development"
   fi
 }
 
 milestone_for_phase() {
   case "$1" in
-    "Developed")
-      echo "v0.6.x Developed"
+    "development-complete")
+      echo "v0.6.x development-complete"
       ;;
-    "Stable")
-      echo "v0.8.x Stable"
+    "stabilized")
+      echo "v0.8.x stabilized"
       ;;
-    "Frozen")
-      echo "v0.9.x Frozen"
+    "frozen")
+      echo "v0.9.x frozen"
       ;;
-    "Ratification-Ready")
-      echo "v0.99.x Ratification-Ready"
+    "ratification-ready")
+      echo "v0.99.0 ratification-ready"
       ;;
-    "Ratified")
-      echo "v1.0.0 Ratified"
+    "publication")
+      echo "v0.99.x publication"
+      ;;
+    "ratified")
+      echo "v1.0.x ratified"
       ;;
     *)
-      echo "Draft and Development"
+      echo "draft-and-development"
       ;;
   esac
 }
 
 phase_floor_version() {
   case "$1" in
-    "Draft and Development")
+    "draft-and-development")
       echo "v0.0.1"
       ;;
-    "Developed")
+    "development-complete")
       echo "v0.6.0"
       ;;
-    "Stable")
+    "stabilized")
       echo "v0.8.0"
       ;;
-    "Frozen")
+    "frozen")
       echo "v0.9.0"
       ;;
-    "Ratification-Ready")
+    "ratification-ready")
       echo "v0.99.0"
       ;;
-    "Ratified")
+    "publication")
+      echo "v0.99.1"
+      ;;
+    "ratified")
       echo "v1.0.0"
       ;;
     *)
@@ -181,19 +207,22 @@ phase_floor_version() {
 
 notice_for_phase() {
   case "$1" in
-    "Draft and Development"|"Developed")
+    "draft-and-development"|"development-complete")
       echo "Assume everything is subject to change. At this stage, ideas, structures, and content are still evolving. Feedback and iteration are encouraged as nothing is final, and adjustments may be frequent."
       ;;
-    "Stable")
+    "stabilized")
       echo "Changes may still occur, but they should be limited in scope. The core structure and content are mostly settled, with only refinements or necessary adjustments expected. Any modifications should be carefully considered to maintain stability."
       ;;
-    "Frozen")
+    "frozen")
       echo "Changes are highly unlikely. A high threshold will be applied, and modifications will only be made in response to critical issues. Any other proposed changes should be addressed through a follow-on extension."
       ;;
-    "Ratification-Ready")
+    "ratification-ready")
       echo "The specification is preparing for ratification. Only critical, ratification-blocking issues should be considered for change."
       ;;
-    "Ratified")
+    "publication")
+      echo "The specification has cleared ratification-ready and is in the publication phase pending final ratification. Only publication-phase corrections are permitted."
+      ;;
+    "ratified")
       echo "No changes are allowed. Any necessary or desired modifications must be addressed through a follow-on extension. Ratified extensions are never revised."
       ;;
     *)
@@ -203,26 +232,13 @@ notice_for_phase() {
 }
 
 revremark_for_phase() {
-  case "$1" in
-    "Draft and Development"|"Developed")
-      echo "This document is under development. Expect potential changes. Visit ${SPEC_STATE_URL} for further details."
-      ;;
-    "Stable")
-      echo "This document is in stable state. Only limited-scope changes are expected. Visit ${SPEC_STATE_URL} for further details."
-      ;;
-    "Frozen")
-      echo "This document is in frozen state. Only critical fixes should be considered. Visit ${SPEC_STATE_URL} for further details."
-      ;;
-    "Ratification-Ready")
-      echo "This document is ratification-ready. Changes are highly restricted pending ratification. Visit ${SPEC_STATE_URL} for further details."
-      ;;
-    "Ratified")
-      echo "This document is ratified. No changes are allowed; use a follow-on extension for updates. Visit ${SPEC_STATE_URL} for further details."
-      ;;
-    *)
-      echo "This document is under development. Visit ${SPEC_STATE_URL} for further details."
-      ;;
-  esac
+  # revremark is rendered immediately under "Version <revnumber>, <revdate>" on
+  # the asciidoctor-pdf title page. Emit only the title-case milestone label so
+  # the title page reads:
+  #   Version v1.0.0, 2026-05-24
+  #          Ratified
+  # The longer policy text moves into the body NOTE admonition (notice_for_phase).
+  phase_display_for_phase "$1"
 }
 
 phase_from_input() {
@@ -276,7 +292,7 @@ case "$command" in
     if [[ -z "$value" ]]; then
       value="$(get_version)"
     fi
-    phase_for_version "$value"
+    phase_display_for_phase "$(phase_for_version "$value")"
     ;;
   milestone)
     phase="$(phase_from_input "$value")"

--- a/scripts/release-info.sh
+++ b/scripts/release-info.sh
@@ -1,0 +1,307 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DEFAULT_VERSION="v0.0.0"
+DEFAULT_PHASE="Draft and Development"
+SPEC_STATE_URL="http://riscv.org/spec-state"
+MAX_PATCH_BEFORE_MINOR_BUMP="${MAX_PATCH_BEFORE_MINOR_BUMP:-99}"
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/release-info.sh [version|normalize|next|phase|phase-floor-version|display|milestone|notice|revremark|all] [value]
+
+Outputs release metadata derived from VERSION/RELEASE_VERSION, git tags, or defaults.
+USAGE
+}
+
+normalize_version() {
+  local v="$1"
+  v="${v##*/}"
+  if [[ "$v" != v* ]]; then
+    v="v${v}"
+  fi
+  echo "$v"
+}
+
+base_version() {
+  local v="$1"
+  v="${v#v}"
+  v="${v%%+*}"
+  v="${v%%-*}"
+  echo "$v"
+}
+
+version_valid() {
+  local v
+  v="$(base_version "$1")"
+  [[ "$v" =~ ^[0-9]+(\.[0-9]+){1,2}$ ]]
+}
+
+parse_version() {
+  local v major minor patch
+  v="$(base_version "$1")"
+  IFS='.' read -r major minor patch <<<"$v"
+  patch="${patch:-0}"
+  echo "$major" "$minor" "$patch"
+}
+
+version_ge() {
+  local a1 b1 c1 a2 b2 c2
+  read -r a1 b1 c1 <<<"$(parse_version "$1")"
+  read -r a2 b2 c2 <<<"$(parse_version "$2")"
+  if (( a1 > a2 )); then
+    return 0
+  fi
+  if (( a1 == a2 && b1 > b2 )); then
+    return 0
+  fi
+  if (( a1 == a2 && b1 == b2 && c1 >= c2 )); then
+    return 0
+  fi
+  return 1
+}
+
+next_version() {
+  local major minor patch
+  read -r major minor patch <<<"$(parse_version "$1")"
+
+  # Progress pre-1.0 development by rolling patch to the next minor at .99.
+  if (( major == 0 && minor < 99 && patch >= MAX_PATCH_BEFORE_MINOR_BUMP )); then
+    minor=$((minor + 1))
+    patch=0
+  else
+    patch=$((patch + 1))
+  fi
+
+  printf 'v%s.%s.%s\n' "$major" "$minor" "$patch"
+}
+
+get_version() {
+  local v=""
+
+  if [[ -n "${VERSION:-}" ]]; then
+    v="$VERSION"
+  elif [[ -n "${RELEASE_VERSION:-}" ]]; then
+    v="$RELEASE_VERSION"
+  elif [[ -n "${GITHUB_REF_NAME:-}" ]]; then
+    if version_valid "$GITHUB_REF_NAME"; then
+      v="$GITHUB_REF_NAME"
+    fi
+  elif [[ -n "${GITHUB_REF:-}" ]]; then
+    local ref="${GITHUB_REF##*/}"
+    if version_valid "$ref"; then
+      v="$ref"
+    fi
+  fi
+
+  if [[ -z "$v" ]] && command -v git >/dev/null 2>&1; then
+    v="$(git tag --list 'v*' --sort=-version:refname | head -n1 || true)"
+  fi
+
+  if [[ -n "$v" ]] && version_valid "$v"; then
+    normalize_version "$v"
+    return 0
+  fi
+
+  echo "$DEFAULT_VERSION"
+}
+
+phase_for_version() {
+  local v="$1"
+
+  if ! version_valid "$v"; then
+    echo "$DEFAULT_PHASE"
+    return 0
+  fi
+
+  if version_ge "$v" "v1.0.0"; then
+    echo "Ratified"
+  elif version_ge "$v" "v0.99.0"; then
+    echo "Ratification-Ready"
+  elif version_ge "$v" "v0.9.0"; then
+    echo "Frozen"
+  elif version_ge "$v" "v0.8.0"; then
+    echo "Stable"
+  elif version_ge "$v" "v0.6.0"; then
+    echo "Developed"
+  else
+    echo "Draft and Development"
+  fi
+}
+
+milestone_for_phase() {
+  case "$1" in
+    "Developed")
+      echo "v0.6.x Developed"
+      ;;
+    "Stable")
+      echo "v0.8.x Stable"
+      ;;
+    "Frozen")
+      echo "v0.9.x Frozen"
+      ;;
+    "Ratification-Ready")
+      echo "v0.99.x Ratification-Ready"
+      ;;
+    "Ratified")
+      echo "v1.0.0 Ratified"
+      ;;
+    *)
+      echo "Draft and Development"
+      ;;
+  esac
+}
+
+phase_floor_version() {
+  case "$1" in
+    "Draft and Development")
+      echo "v0.0.1"
+      ;;
+    "Developed")
+      echo "v0.6.0"
+      ;;
+    "Stable")
+      echo "v0.8.0"
+      ;;
+    "Frozen")
+      echo "v0.9.0"
+      ;;
+    "Ratification-Ready")
+      echo "v0.99.0"
+      ;;
+    "Ratified")
+      echo "v1.0.0"
+      ;;
+    *)
+      echo "Unknown phase '$1'" >&2
+      return 2
+      ;;
+  esac
+}
+
+notice_for_phase() {
+  case "$1" in
+    "Draft and Development"|"Developed")
+      echo "Assume everything is subject to change. At this stage, ideas, structures, and content are still evolving. Feedback and iteration are encouraged as nothing is final, and adjustments may be frequent."
+      ;;
+    "Stable")
+      echo "Changes may still occur, but they should be limited in scope. The core structure and content are mostly settled, with only refinements or necessary adjustments expected. Any modifications should be carefully considered to maintain stability."
+      ;;
+    "Frozen")
+      echo "Changes are highly unlikely. A high threshold will be applied, and modifications will only be made in response to critical issues. Any other proposed changes should be addressed through a follow-on extension."
+      ;;
+    "Ratification-Ready")
+      echo "The specification is preparing for ratification. Only critical, ratification-blocking issues should be considered for change."
+      ;;
+    "Ratified")
+      echo "No changes are allowed. Any necessary or desired modifications must be addressed through a follow-on extension. Ratified extensions are never revised."
+      ;;
+    *)
+      echo "Assume everything is subject to change until a formal milestone is reached."
+      ;;
+  esac
+}
+
+revremark_for_phase() {
+  case "$1" in
+    "Draft and Development"|"Developed")
+      echo "This document is under development. Expect potential changes. Visit ${SPEC_STATE_URL} for further details."
+      ;;
+    "Stable")
+      echo "This document is in stable state. Only limited-scope changes are expected. Visit ${SPEC_STATE_URL} for further details."
+      ;;
+    "Frozen")
+      echo "This document is in frozen state. Only critical fixes should be considered. Visit ${SPEC_STATE_URL} for further details."
+      ;;
+    "Ratification-Ready")
+      echo "This document is ratification-ready. Changes are highly restricted pending ratification. Visit ${SPEC_STATE_URL} for further details."
+      ;;
+    "Ratified")
+      echo "This document is ratified. No changes are allowed; use a follow-on extension for updates. Visit ${SPEC_STATE_URL} for further details."
+      ;;
+    *)
+      echo "This document is under development. Visit ${SPEC_STATE_URL} for further details."
+      ;;
+  esac
+}
+
+phase_from_input() {
+  local input="${1:-}"
+  if [[ -z "$input" ]]; then
+    phase_for_version "$(get_version)"
+  elif version_valid "$input"; then
+    phase_for_version "$input"
+  else
+    echo "$input"
+  fi
+}
+
+command="${1:-all}"
+value="${2:-}"
+
+case "$command" in
+  version)
+    get_version
+    ;;
+  normalize)
+    if [[ -z "$value" ]]; then
+      echo "normalize requires a version value" >&2
+      exit 2
+    fi
+    if ! version_valid "$value"; then
+      echo "invalid version: $value" >&2
+      exit 2
+    fi
+    normalize_version "$value"
+    ;;
+  next)
+    if [[ -z "$value" ]]; then
+      value="$(get_version)"
+    fi
+    next_version "$value"
+    ;;
+  phase)
+    if [[ -z "$value" ]]; then
+      value="$(get_version)"
+    fi
+    phase_for_version "$value"
+    ;;
+  phase-floor-version)
+    if [[ -z "$value" ]]; then
+      value="$(phase_for_version "$(get_version)")"
+    fi
+    phase_floor_version "$value"
+    ;;
+  display)
+    if [[ -z "$value" ]]; then
+      value="$(get_version)"
+    fi
+    phase_for_version "$value"
+    ;;
+  milestone)
+    phase="$(phase_from_input "$value")"
+    milestone_for_phase "$phase"
+    ;;
+  notice)
+    phase="$(phase_from_input "$value")"
+    notice_for_phase "$phase"
+    ;;
+  revremark)
+    phase="$(phase_from_input "$value")"
+    revremark_for_phase "$phase"
+    ;;
+  all|"")
+    version="$(get_version)"
+    phase="$(phase_for_version "$version")"
+    display="$phase"
+    milestone="$(milestone_for_phase "$phase")"
+    notice="$(notice_for_phase "$phase")"
+    revremark="$(revremark_for_phase "$phase")"
+    printf 'VERSION=%s\nPHASE=%s\nPHASE_DISPLAY=%s\nMILESTONE=%s\nPHASE_NOTICE=%s\nREVMARK=%s\n' \
+      "$version" "$phase" "$display" "$milestone" "$notice" "$revremark"
+    ;;
+  *)
+    usage
+    exit 2
+    ;;
+esac

--- a/scripts/update-spec-state.sh
+++ b/scripts/update-spec-state.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: scripts/update-spec-state.sh <version> [date]" >&2
+  exit 2
+fi
+
+version="$1"
+updated_on="${2:-$(date +%Y-%m-%d)}"
+
+phase="$(./scripts/release-info.sh phase "$version")"
+milestone="$(./scripts/release-info.sh milestone "$version")"
+
+cat > SPEC_STATE.md <<STATE
+# Specification State
+
+Current milestone: ${milestone}
+Current state: ${phase}
+Current version: ${version}
+Last updated: ${updated_on}
+
+## Milestone Targets
+
+- v0.6.x Developed
+- v0.8.x Stable
+- v0.9.x Frozen
+- v0.99.x Ratification-Ready
+- v1.0.0 Ratified
+
+## State Definitions
+
+### Draft and Development
+
+Assume everything is subject to change. At this stage, ideas, structures, and content are still evolving. Feedback and iteration are encouraged as nothing is final, and adjustments may be frequent.
+
+### Developed
+
+Assume everything is subject to change. At this stage, ideas, structures, and content are still evolving. Feedback and iteration are encouraged as nothing is final, and adjustments may be frequent.
+
+### Stable
+
+Changes may still occur, but they should be limited in scope. The core structure and content are mostly settled, with only refinements or necessary adjustments expected. Any modifications should be carefully considered to maintain stability.
+
+### Frozen
+
+Changes are highly unlikely. A high threshold will be applied, and modifications will only be made in response to critical issues. Any other proposed changes should be addressed through a follow-on extension.
+
+### Ratification-Ready
+
+The specification is preparing for ratification. Only critical, ratification-blocking issues should be considered for change.
+
+### Ratified
+
+No changes are allowed. Any necessary or desired modifications must be addressed through a follow-on extension. Ratified extensions are never revised.
+STATE

--- a/src/spec-sample.adoc
+++ b/src/spec-sample.adoc
@@ -1,11 +1,14 @@
 = RISC-V Example Specification Document (Zexmpl)
 Authors: Author 1, Author 2
 include::../docs-resources/global-config.adoc[]
+ifndef::revnumber[:revnumber: v0.0.0]
+ifndef::revdate[:revdate: 1/2023]
+ifndef::phase[:phase: Draft and Development]
+ifndef::phase_display[:phase_display: {phase}]
+ifndef::phase_notice[:phase_notice: Assume everything is subject to change. At this stage, ideas, structures, and content are still evolving. Feedback and iteration are encouraged as nothing is final, and adjustments may be frequent.]
+ifndef::revremark[:revremark: This document is under development. Expect potential changes. Visit http://riscv.org/spec-state for further details.]
 :docgroup: RISC-V Task Group
 :description: RISC-V Example Specification Document (Zexmpl)
-:revdate: 1/2023
-:revnumber: 1.0
-:revremark: This document is under development. Expect potential changes. Visit http://riscv.org/spec-state for further details.
 :revinfo:
 :preface-title: Preamble
 :colophon:
@@ -51,11 +54,9 @@ list-of::table[hide_empty_section=true, enhanced_rendering=true]
 list-of::listing[hide_empty_section=true, enhanced_rendering=true]
 
 [WARNING]
-.This document is in the link:http://riscv.org/spec-state[Development state]
+.This document is in the link:http://riscv.org/spec-state[{phase_display} state]
 ====
-Expect potential changes. This draft specification is likely to evolve before
-it is accepted as a standard. Implementations based on this draft
-may not conform to the future standard.
+{phase_notice}
 ====
 
 [preface]

--- a/src/spec-sample.adoc
+++ b/src/spec-sample.adoc
@@ -3,10 +3,12 @@ Authors: Author 1, Author 2
 include::../docs-resources/global-config.adoc[]
 ifndef::revnumber[:revnumber: v0.0.0]
 ifndef::revdate[:revdate: 1/2023]
-ifndef::phase[:phase: Draft and Development]
+ifndef::phase[:phase: draft-and-development]
 ifndef::phase_display[:phase_display: {phase}]
 ifndef::phase_notice[:phase_notice: Assume everything is subject to change. At this stage, ideas, structures, and content are still evolving. Feedback and iteration are encouraged as nothing is final, and adjustments may be frequent.]
 ifndef::revremark[:revremark: This document is under development. Expect potential changes. Visit http://riscv.org/spec-state for further details.]
+ifndef::milestone_id[:milestone_id: {phase}]
+ifndef::spec_short[:spec_short: spec-sample]
 :docgroup: RISC-V Task Group
 :description: RISC-V Example Specification Document (Zexmpl)
 :revinfo:
@@ -29,8 +31,9 @@ ifndef::revremark[:revremark: This document is under development. Expect potenti
 :lang: en
 :listing-caption: Listing
 :sectnums:
-:toc: left
+:toc: macro
 :toclevels: 4
+:toc-title: Table of Contents
 :source-highlighter: pygments
 ifdef::backend-pdf[]
 :source-highlighter: coderay
@@ -40,6 +43,14 @@ endif::[]
 :stem: latexmath
 :footnote:
 :xrefstyle: short
+
+// "Document State" preface is the phase Note rendered as page 2 of the PDF
+// (TOC is placed after it via the toc::[] macro below). See ARC_SUBMISSION.md §3.3.
+[preface]
+== Document State
+*Note:* {phase_notice}
+
+toc::[]
 
 [preface]
 == List of figures
@@ -52,12 +63,6 @@ list-of::table[hide_empty_section=true, enhanced_rendering=true]
 [preface]
 == List of listings
 list-of::listing[hide_empty_section=true, enhanced_rendering=true]
-
-[WARNING]
-.This document is in the link:http://riscv.org/spec-state[{phase_display} state]
-====
-{phase_notice}
-====
 
 [preface]
 == Copyright and license information


### PR DESCRIPTION
## Summary

Implements the ARC submission requirements (announced 2026-05-24): every spec submitted for ARC review must be a GitHub tag with a PDF named `<short>-v<X.Y.Z>-<YYYYMMDD>.pdf` and a title page that matches.

- **Six canonical milestone IDs** drive every artifact: `development-complete`, `stabilized`, `frozen`, `ratification-ready`, `publication`, `ratified`. The version number (`v0.6.0` / `v0.8.0` / `v0.9.0` / `v0.99.0` / `v0.99.1` / `v1.0.0`) encodes the gate.
- **The build emits ARC-compliant artifacts on every run** — no separate "ARC build" target. `make` and the CI workflow both produce `build/<short>-v<X.Y.Z>-<YYYYMMDD>.pdf`.
- **The title-page revision line** reads `Version v1.0.0, 2026-05-24: Ratified`. A new "Document State" preface (page 2) renders the phase notice as a `Note:` paragraph. No theme/submodule edits required.

## Commits in this PR

| SHA | What |
|---|---|
| `47bb111` | **Automate Versioning** — foundational versioning automation Rafael had locally (script-driven version bumps + milestone-floor inference + workflow integration). The ARC convention sits on top of this. |
| `9b9d83f` | **Adopt ARC submission convention** — the policy + toolchain (release-info.sh canonical IDs, Makefile arc-rename, CI workflow refresh, Document State preface, ARC_SUBMISSION.md, MIGRATION.md, README callout). |
| `4ca22e3` | **Ignore .DS_Store in .gitignore** — hygiene so macOS Finder metadata doesn't leak into downstream PRs. |

## What changed (file-level)

| File | Why |
|---|---|
| `scripts/release-info.sh` | Six canonical milestone IDs; `publication` band added between rat-ready and ratified; `phase_display_for_phase` emits title-case labels for the title page; `revremark` is now the display label only. |
| `Makefile` | New `SPEC_SHORT`, `DATE_STAMP`, `VERSION_NUM`, `MILESTONE_ID`. `arc-rename` target renames `build/<base>.pdf` → `build/<base>-v<X.Y.Z>-<YYYYMMDD>.pdf` on every build. |
| `.github/workflows/build-pdf.yml` | `target_phase` enum uses canonical IDs; `v0.99.1` recognized as official release; `VERSION`/`DATE` exported to the build step. |
| `.github/workflows/version-bot.yml` | `target_phase` enum refreshed to canonical IDs. |
| `src/spec-sample.adoc` | `:toc: macro`; new `[preface] == Document State` block with `*Note:* {phase_notice}`; `toc::[]` after; defaults for `milestone_id` and `spec_short`. |
| `README.adoc` | IMPORTANT callout pointing at `ARC_SUBMISSION.md` and `MIGRATION.md`. |
| `ARC_SUBMISSION.md` | **New.** Policy document. Verbatim ARC notice + version→milestone mapping + filename/title-page rules + pre-submission checklist. |
| `MIGRATION.md` | **New.** 8-step checklist for downstream spec repos to adopt the toolchain without rewriting existing tags. |
| `.gitignore` | Add `.DS_Store` (top-level + recursive). |

## Document layout (rendered)

| Page | Content |
|---|---|
| 1 | Title page — `RISC-V Example Specification Document (Zexmpl)` + authors + `Version vX.Y.Z, YYYY-MM-DD: <Milestone Display>` |
| 2 | **Document State** preface — `Note: <phase notice>` |
| 3 | Table of Contents |
| 4+ | List of figures, list of tables, list of listings, body |

## Validation

Built all seven milestone phases locally (Docker container, asciidoctor-pdf 2.3.24):

| PDF | Title-page revision line | Page 2 Note (first ~80 chars) |
|---|---|---|
| `spec-sample-v0.5.0-20260524.pdf` | `Version v0.5.0, 2026-05-24: Draft and Development` | `Assume everything is subject to change...` |
| `spec-sample-v0.6.0-20260524.pdf` | `Version v0.6.0, 2026-05-24: Development Complete` | `Assume everything is subject to change...` |
| `spec-sample-v0.8.0-20260524.pdf` | `Version v0.8.0, 2026-05-24: Stabilized` | `Changes may still occur, but they should be limited in scope...` |
| `spec-sample-v0.9.0-20260524.pdf` | `Version v0.9.0, 2026-05-24: Frozen` | `Changes are highly unlikely. A high threshold will be applied...` |
| `spec-sample-v0.99.0-20260524.pdf` | `Version v0.99.0, 2026-05-24: Ratification-Ready` | `The specification is preparing for ratification...` |
| `spec-sample-v0.99.1-20260524.pdf` | `Version v0.99.1, 2026-05-24: Publication` | `The specification has cleared ratification-ready...` |
| `spec-sample-v1.0.0-20260524.pdf` | `Version v1.0.0, 2026-05-24: Ratified` | `No changes are allowed. Any necessary or desired modifications...` |

## Test plan

- [ ] Review `ARC_SUBMISSION.md` for policy accuracy (especially the version→milestone mapping table and the verbatim ARC notice in §0).
- [ ] Review `MIGRATION.md` for completeness — would a downstream maintainer be able to follow it without asking questions?
- [ ] Trigger `Create Specification Document` workflow on this branch with `target_phase=stabilized` and confirm the resulting Release attaches a single `spec-sample-v0.8.0-<YYYYMMDD>.pdf`.
- [ ] Open one of the validation PDFs and visually confirm the page 1 / page 2 / page 3 layout.
- [ ] Confirm no `.DS_Store` files appear in the diff.

## Cleanup done before this PR

- Deleted stale `vtest` and `vtest_1` tags (local + remote). Legitimate template release tags (`v1.0.0`, `v2.0.0`, `v3.0.0`, `v4.0.0`–`v4.0.2`, `v0.1.0-example`, `v1.0_rc1`) are preserved — they're part of the template's own version history.
