### PR TITLE
Fix trailing whitespace in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,14 +56,14 @@ Please use your real name in the sign-off message.
    You can manually add the DCO text to your commit body or include either -s or --signoff in your standard Git commit commands. If you forget to incorporate the sign-off, you can also
    amend a previous commit with the sign-off by executing git commit --amend -s. If you have already pushed your changes to GitHub, you will need to force push your branch afterward
    using git push -f.
-   
+
 2) Automated Template method (easier)
 
    Create a template file.  Save a file (e.g., ~/.gitmessage) containing:
     Signed-off-by: Your Name <your.email@example.com>
 
    Configure Git to use it.  Run the following command:
-    git config --global commit.template ~/.gitmessage     
+    git config --global commit.template ~/.gitmessage  
 
 Note:
 


### PR DESCRIPTION
The `trim trailing whitespace` pre-commit hook fails on a clean checkout of this template, and therefore on **every repository generated from it** (the hook modifies `CONTRIBUTING.md` and pre-commit exits non-zero).

This strips the two offending trailing-whitespace occurrences in `CONTRIBUTING.md` so `pre-commit run --all-files` passes out of the box and newly generated spec repos start with a green CI.

Whitespace-only change; verified `pre-commit run --all-files` passes afterward.