### PR TITLE
Exclude antora.yml from yamlfmt and patch files from whitespace hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,8 +7,13 @@ repos:
       - id: check-symlinks
       - id: check-yaml
       - id: end-of-file-fixer
+        exclude: \.patch$
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
+        # Patch files are byte-sensitive: context lines carry a leading space and
+        # blank context lines are a single space. Reformatting them can corrupt
+        # the patch.
+        exclude: \.patch$
 
   - repo: local
     hooks:
@@ -24,3 +29,8 @@ repos:
     hooks:
       - id: yamlfmt
         args: [--mapping, '2', --sequence, '4', --offset, '2']
+        # antora.yml is rewritten at release time by scripts/stamp-antora-version.sh,
+        # which replaces values line by line. yamlfmt line-wraps long plain scalars
+        # (e.g. page-phase-notice), which splits a value across two lines and makes
+        # the stamp emit invalid YAML. Leave this file alone.
+        exclude: ^antora\.yml$


### PR DESCRIPTION
Prep for the Antora migration in #105. Narrowly scoped to `.pre-commit-config.yaml`.

## Why

#105 adds `scripts/stamp-antora-version.sh`, which rewrites `antora.yml` at release time by replacing values line by line (awk, keyed on `^    page-phase-notice:` and friends).

`yamlfmt` line-wraps long plain scalars. When it wraps `page-phase-notice` across two lines, the stamp script replaces only the first line and orphans the second, emitting invalid YAML:

```yaml
    page-phase-notice: 'Changes may still occur, but they should be limited in scope...'
      are encouraged as nothing is final, and adjustments may be frequent.   # <-- orphan
```

```
$ python3 -c "import yaml; yaml.safe_load(open('antora.yml'))"
expected <block end>, but found '<scalar>'
```

The script still exits 0, so the failure is silent.

Excluding `antora.yml` from `yamlfmt` keeps the file in a shape the stamp script can rewrite safely.

## Scope

This is a **guard, not a fix.** It prevents the wrap from being reintroduced; it does not repair an already-wrapped file. #105 still needs to un-wrap `page-phase-notice` (or make it a `>-` block scalar) and harden the stamp script to assert its substitutions landed and the result parses. Both changes are being raised on that PR.

## Also here

`*.patch` is excluded from `trailing-whitespace` and `end-of-file-fixer`. Patch files are byte-sensitive — context lines carry a leading space, blank context lines are a single space — so whitespace fixers can corrupt them.

This is not hypothetical. On `main` today both hooks rewrite `0001-Automate-Versioning.patch`, stripping 14 single-space context lines:

```
$ pre-commit run trailing-whitespace --files 0001-Automate-Versioning.patch
trim trailing whitespace.................................................Failed
$ pre-commit run end-of-file-fixer --files 0001-Automate-Versioning.patch
fix end of files.........................................................Failed
```

That is the same churn visible in #105. The stripped result still applies (`git apply --numstat` succeeds), so nothing is broken today — but a byte-sensitive artifact should not be passing through a whitespace fixer at all.

## Related

- #107 normalizes the pre-existing yamlfmt drift on `main` (`build-pdf.yml`, `version-bot.yml`). Independent of this PR (different files); together they make `main` fully pre-commit clean.