### PR TITLE
Normalize yamlfmt formatting in build-pdf.yml and version-bot.yml

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -6,11 +6,11 @@ on:
   workflow_dispatch:
     inputs:
       release_version:
-        description: 'Override version (e.g., v0.8.2). Milestone floors become official releases.'
+        description: Override version (e.g., v0.8.2). Milestone floors become official releases.
         required: false
         type: string
       target_phase:
-        description: 'Pick a milestone floor (recommended for official releases).'
+        description: Pick a milestone floor (recommended for official releases).
         required: false
         type: choice
         default: auto-next
@@ -31,7 +31,7 @@ on:
   pull_request:
   push:
     tags:
-      - 'v*'
+      - v*
 
 jobs:
   build:

--- a/.github/workflows/version-bot.yml
+++ b/.github/workflows/version-bot.yml
@@ -6,11 +6,11 @@ on:
     branches:
       - main
     paths:
-      - 'src/**'
+      - src/**
   workflow_dispatch:
     inputs:
       target_phase:
-        description: 'Force-jump to the milestone floor version for this phase'
+        description: Force-jump to the milestone floor version for this phase
         required: false
         type: choice
         default: auto-next
@@ -24,11 +24,11 @@ on:
           - publication
           - ratified
       release_version:
-        description: 'Explicit version override (e.g., v0.9.0). If set, target_phase is ignored.'
+        description: Explicit version override (e.g., v0.9.0). If set, target_phase is ignored.
         required: false
         type: string
       allow_non_monotonic:
-        description: 'Allow jumps lower than the latest existing version tag'
+        description: Allow jumps lower than the latest existing version tag
         required: false
         type: boolean
         default: false
@@ -147,10 +147,10 @@ jobs:
       - name: Create milestone review PR
         uses: peter-evans/create-pull-request@v6
         with:
-          commit-message: "docs: milestone transition to ${{ needs.tag-version.outputs.next_phase }}"
-          branch: "gitbot/milestone-${{ needs.tag-version.outputs.next_version }}"
+          commit-message: 'docs: milestone transition to ${{ needs.tag-version.outputs.next_phase }}'
+          branch: gitbot/milestone-${{ needs.tag-version.outputs.next_version }}
           delete-branch: true
-          title: "Milestone reached: ${{ needs.tag-version.outputs.next_phase }} (${{ needs.tag-version.outputs.next_version }})"
+          title: 'Milestone reached: ${{ needs.tag-version.outputs.next_phase }} (${{ needs.tag-version.outputs.next_version }})'
           body: |
             This PR was opened automatically after a version milestone transition.
 


### PR DESCRIPTION
Pure formatting. No behavioural change.

## Why

`main` is not pre-commit clean today. On an untouched checkout:

```
$ pre-commit run yamlfmt --all-files
Format YAML files........................................................Failed
- hook id: yamlfmt
- files were modified by this hook

$ git status --porcelain
 M .github/workflows/build-pdf.yml
 M .github/workflows/version-bot.yml
```

This drift leaks into unrelated feature branches as review noise. It is visible in #105, where a formatting-only commit reformatted both workflows alongside the actual Antora work:

```diff
-        description: 'Force-jump to the milestone floor version for this phase'
+        description: Force-jump to the milestone floor version for this phase
```

That is not a change the author intended to make — it is this drift surfacing.

## What this does

Applies yamlfmt's own output to the two files it rewrites. Nothing hand-edited.

Verified formatting-only by parsing both files before and after and comparing the resulting structures:

```
.github/workflows/build-pdf.yml: parsed-identical=True
.github/workflows/version-bot.yml: parsed-identical=True
```

## Root cause worth a follow-up

`required_status_checks.contexts` on `main` is empty, so the **pre-commit** workflow is not a required check and PRs can merge with it failing. That is how the drift accumulated, and it will accumulate again. Making pre-commit required would prevent a recurrence — happy to do that separately if there is appetite.

## Related

- #106 excludes `antora.yml` from yamlfmt and `*.patch` from the whitespace hooks. Independent of this PR (different files); together they make `main` fully pre-commit clean.