### PR TITLE
Add non-ratified 'doc' mode to the template

### DIFF
--- a/.docmode
+++ b/.docmode
@@ -1,0 +1,9 @@
+spec
+# Template mode for this repository. Keep the value on the FIRST line above.
+# One of:
+#   spec  - ratified RISC-V specification (ARC / Policies & Procedures process). Default.
+#   doc   - non-ratified documentation: Antora-ready with PDF + Makefile HTML,
+#           but no ratification layer (no milestone phases, no "Document State"
+#           page, no ARC submission).
+# An admin sets this ONCE when creating the repo; authors never touch it.
+# See ANTORA.md "Template modes: spec vs doc" for details.

--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -181,6 +181,58 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GHTOKEN || secrets.GITHUB_TOKEN }}
         if: github.event_name == 'workflow_dispatch' && env.OFFICIAL_RELEASE != 'true'
 
+  # Doc-mode smoke build. The `build` job above exercises the committed mode
+  # (spec by default); now that the template ships two modes, build the OTHER
+  # path on every PR too, so a change that only breaks doc mode can't merge
+  # green. Uses a DOC_MODE=doc env override (never edits committed .docmode) and
+  # asserts a PDF lands -- it publishes and releases nothing. Also round-trips
+  # set-mode.sh (spec -> doc -> spec) to guard the fragile antora.yml awk.
+  # PR-only so it never interferes with release/tag builds or the stamp job.
+  doc-mode-smoke:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Pull Container
+        run: docker pull riscvintl/riscv-docs-base-container-image:latest
+
+      - name: Build in doc mode
+        run: |
+          set -euo pipefail
+          # Env override builds the doc path without touching the committed mode.
+          make DOC_MODE=doc
+          shopt -s nullglob
+          pdfs=(build/*.pdf)
+          if [ "${#pdfs[@]}" -eq 0 ]; then
+            echo "doc-mode smoke FAILED: no PDF produced" >&2
+            exit 1
+          fi
+          echo "doc-mode smoke OK: ${pdfs[*]}"
+
+      - name: Round-trip set-mode.sh (spec -> doc -> spec)
+        run: |
+          set -euo pipefail
+          has_phase() { grep -qE '^[[:space:]]*page-phase:' antora.yml; }
+          # doc mode must STRIP the page-phase* block ...
+          scripts/set-mode.sh doc
+          if has_phase; then
+            echo "set-mode FAILED: doc mode left page-phase* in antora.yml" >&2
+            exit 1
+          fi
+          # ... and switching back to spec must RESTORE it. A broken awk (e.g. an
+          # indentation-assumption regression) fails one of these directions.
+          scripts/set-mode.sh spec
+          if ! has_phase; then
+            echo "set-mode FAILED: spec mode did not restore page-phase* in antora.yml" >&2
+            exit 1
+          fi
+          echo "set-mode round-trip OK"
+
   # Keep the Antora HTML site version in EXACT lockstep with the PDF this run just
   # built: stamp the SAME resolved version/date into antora.yml on main, so the
   # central playbook publishes the version the PDF carries. The PDF and this stamp

--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -62,9 +62,12 @@ jobs:
         id: set_build_version
         run: |
           set -euo pipefail
+          # Doc mode (non-ratified) has no milestone floors; the target_phase
+          # input is inert, so ignore it and fall through to auto-next.
+          mode="$(awk 'NF && $1 !~ /^#/ { print $1; exit }' .docmode 2>/dev/null || echo spec)"
           if [ -n "${{ github.event.inputs.release_version }}" ]; then
             version="${{ github.event.inputs.release_version }}"
-          elif [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.event.inputs.target_phase }}" != "auto-next" ]; then
+          elif [ "$mode" != "doc" ] && [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.event.inputs.target_phase }}" != "auto-next" ]; then
             version="$(./scripts/release-info.sh phase-floor-version "${{ github.event.inputs.target_phase }}")"
           elif [ "${{ github.ref_type }}" = "tag" ]; then
             version="${{ github.ref_name }}"

--- a/.github/workflows/version-bot.yml
+++ b/.github/workflows/version-bot.yml
@@ -69,6 +69,9 @@ jobs:
           latest="$(git tag --list 'v*' --sort=-version:refname | head -n1 || true)"
           latest="${latest:-v0.0.0}"
 
+          # Doc mode (non-ratified) has no milestone floors; ignore target_phase.
+          mode="$(awk 'NF && $1 !~ /^#/ { print $1; exit }' .docmode 2>/dev/null || echo spec)"
+
           if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
             if [[ "$REF_NAME" != "main" ]]; then
               echo "Manual version jump must run against main." >&2
@@ -77,7 +80,7 @@ jobs:
 
             if [[ -n "${RELEASE_VERSION:-}" ]]; then
               next="$(./scripts/release-info.sh normalize "$RELEASE_VERSION")"
-            elif [[ -n "${TARGET_PHASE:-}" && "$TARGET_PHASE" != "auto-next" ]]; then
+            elif [[ "$mode" != "doc" && -n "${TARGET_PHASE:-}" && "$TARGET_PHASE" != "auto-next" ]]; then
               next="$(./scripts/release-info.sh phase-floor-version "$TARGET_PHASE")"
             else
               next="$(./scripts/release-info.sh next "$latest")"

--- a/ANTORA.md
+++ b/ANTORA.md
@@ -14,6 +14,46 @@ to finish that migration.
 - Build the PDF: `make` → `build/<short>-v<ver>-<YYYYMMDD>.pdf`.
 - Build the site locally: `antora antora-playbook.yml` → `build/site/`.
 
+## Template modes: `spec` vs `doc`
+
+This template runs in one of two modes, selected once by the committed
+`.docmode` file at the repo root (a RISC-V admin sets it when the repo is
+created; authors never touch it). If `.docmode` is absent, the mode is `spec` —
+so existing spec repos are unaffected.
+
+| | `spec` (default) | `doc` |
+|---|---|---|
+| Intended for | Ratified RISC-V specifications (ARC/P&P process) | Non-ratified documentation (e.g. the Docs Dev Guide) |
+| ARC PDF | ✅ `<short>-vX.Y.Z-YYYYMMDD.pdf` | ✅ same filename form |
+| Makefile HTML | ✅ | ✅ |
+| Antora site | ✅ | ✅ |
+| Version scheme | semver tags → milestone phase gates | semver tags + build date, **no** phase gates |
+| "Document State" preface (PDF) | ✅ | ❌ omitted |
+| Phase banner + `spec-state` link (site cover) | ✅ | ❌ omitted |
+| Milestone version-bot / milestone PRs | ✅ | ❌ inert (plain patch bumps) |
+| `SPEC_STATE.md`, `ARC_SUBMISSION.md` | apply | not used |
+
+**How the switch flows.** `scripts/release-info.sh` reads `.docmode` and, in
+`doc` mode, returns an empty phase/display/notice/milestone (the shared version
+plumbing is unchanged). The `Makefile` reads/exports `DOC_MODE` and, in `doc`
+mode, passes the `doc-mode` AsciiDoc attribute so `src/*.adoc` omits the
+"Document State" preface. The Antora cover page (`modules/ROOT/pages/index.adoc`)
+guards its phase suffix/banner on `ifdef::page-phase-*`, and
+`scripts/stamp-antora-version.sh` requires only `version`/`page-revnumber`/
+`page-revdate` in `doc` mode (no `page-phase*` keys). CI ignores the milestone
+`target_phase` inputs in `doc` mode.
+
+**Changing mode after setup.** The mode is reversible — if it was set in error you
+do **not** need to recreate the repo. Run `make set-mode MODE=doc` (or `MODE=spec`).
+It flips `.docmode` and reconciles `antora.yml` in one step: the two modes expect a
+different descriptor shape (spec carries the `page-phase*` cover attributes; doc
+omits them), so the helper strips or re-inserts that block and re-stamps. It leaves
+content files (`SPEC_STATE.md`, `ARC_SUBMISSION.md`) and git tags alone, printing a
+reminder instead. Commit the resulting `.docmode` + `antora.yml`.
+
+To migrate an existing documentation repo to `doc` mode, see the "doc-mode path"
+in `MIGRATION.md`.
+
 ## The dual-source technique (why it works)
 
 The PDF wants one master document; Antora wants one file per navigable page.
@@ -265,6 +305,7 @@ unnumbered back matter).
 ```bash
 make                          # ARC PDF (+ HTML) via Docker; VERSION/DATE overridable
 make stamp-antora VERSION=vX.Y.Z   # stamp antora.yml to match the PDF release (commit the result)
+make set-mode MODE=doc        # switch template mode in place (spec|doc); reconciles antora.yml
 
 # Local Antora preview (renders like production: diagrams + math):
 npm install                   # one-time: Antora + kroki/mathjax extensions

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -43,7 +43,57 @@ is the sequence of actions; ANTORA.md is the rationale.
 
 ---
 
-# Part A — ARC PDF compliance
+# Choose your mode
+
+This template runs in two modes (see `ANTORA.md` §"Template modes"), selected by
+the committed `.docmode` file:
+
+- **`spec` mode** (default) — ratified RISC-V specifications on the ARC/P&P
+  process. Follow **all** of Parts A, B, and C below.
+- **`doc` mode** — non-ratified documentation that still needs the PDF, the
+  Makefile HTML, and the Antora site, but **no** ratification layer (no milestone
+  phases, no "Document State" preface, no ARC submission). Example:
+  [`riscv/docs-dev-guide`](https://github.com/riscv/docs-dev-guide).
+
+Parts A and C are written for `spec` mode. **Doc-mode migrators**: use the
+condensed checklist below instead of reading A/C top to bottom — the toolchain is
+already mode-aware, so most of the work is the shared Antora layout in Part B.
+
+## Doc-mode checklist
+
+1. [ ] **Set the mode.** Add a `.docmode` file at the repo root containing
+       `doc`. This single file makes `release-info.sh`, the `Makefile`, the stamp
+       script, and CI all skip the ratification layer. (An admin creating a fresh
+       repo from the template does this once; a migrating repo adds it here.) If a
+       repo already has an `antora.yml`, prefer `make set-mode MODE=doc`, which
+       flips `.docmode` **and** reconciles the descriptor's `page-phase*` block in
+       one step; the mode is reversible either way.
+2. [ ] **Sync the toolchain** (Part A, Steps 1–3): take the upstream
+       `scripts/release-info.sh`, `Makefile`, and `.github/workflows/build-pdf.yml`.
+       They read `.docmode` and neutralize the phase/milestone surface
+       automatically — you do **not** need the ARC milestone semantics.
+3. [ ] **Update your top-level `.adoc` assembler** (Part A, Step 5) to the
+       dual-source form, **and** wrap the ratification-only bits in
+       `ifndef::doc-mode[] … endif::[]`: the `[preface] == Document State` block
+       and the `spec-state` `revremark` default (see `src/spec-sample.adoc` for
+       the exact guards).
+4. [ ] **Do the whole of Part B** (the Antora site): dual-source layout,
+       `antora.yml`, `modules/ROOT/nav.adoc`, local preview tooling, central
+       playbook registration, and the content-source CI gate. **One difference:**
+       in `antora.yml`, omit the `page-phase`, `page-phase-display`, and
+       `page-phase-notice` attributes — doc mode has no phase. The cover page and
+       stamp script already tolerate their absence.
+5. [ ] **Skip Part C** (ARC submission) and `SPEC_STATE.md` / `ARC_SUBMISSION.md`
+       — they do not apply. Cut releases by tagging `vX.Y.Z`; the PDF and site
+       version track the tag + build date, and version-bot does plain patch bumps
+       (no milestone PRs).
+6. [ ] **Verify** (Part B, Step 6 + the site steps): `make` produces a PDF with
+       **no** "Document State" page; `npm run preview` renders a cover with no
+       phase banner.
+
+---
+
+# Part A — ARC PDF compliance *(spec mode; doc mode: see the checklist above)*
 
 ## Step 1 — Sync `scripts/release-info.sh`
 
@@ -436,7 +486,7 @@ file.
 
 ---
 
-# Part C — Release and submit
+# Part C — Release and submit *(spec mode only; doc mode: tag `vX.Y.Z` and skip)*
 
 ## Step 14 — Cut your next release
 

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,13 @@ DOCS := \
 # Override in derived repos: e.g. SPEC_SHORT := Zifoo
 SPEC_SHORT ?= $(basename $(firstword $(DOCS)))
 
+# Template mode: "spec" (ratified, ARC/P&P milestones) or "doc" (non-ratified
+# documentation). Read once from the committed .docmode file; absent => "spec".
+# Exported BEFORE the release-info.sh shell calls below so an env/CLI override
+# (`make DOC_MODE=doc`) propagates into them and the phase surface goes neutral.
+DOC_MODE ?= $(shell awk 'NF && $$1 !~ /^#/ { print $$1; exit }' .docmode 2>/dev/null || echo spec)
+export DOC_MODE
+
 DATE ?= $(shell date +%Y-%m-%d)
 DATE_STAMP := $(subst -,,$(DATE))
 VERSION ?= $(shell ./scripts/release-info.sh version)
@@ -53,6 +60,11 @@ DOCS_PDF := $(DOCS:%.adoc=%.pdf)
 DOCS_HTML := $(DOCS:%.adoc=%.html)
 
 XTRA_ADOC_OPTS :=
+# In doc mode, set the `doc-mode` AsciiDoc attribute so the PDF assembler omits
+# the ratification-only "Document State" preface (see src/*.adoc guards).
+ifeq ($(DOC_MODE),doc)
+XTRA_ADOC_OPTS += -a doc-mode
+endif
 ASCIIDOCTOR_PDF := asciidoctor-pdf
 ASCIIDOCTOR_HTML := asciidoctor
 OPTIONS := --trace \
@@ -76,9 +88,17 @@ REQUIRES := --require=asciidoctor-bibtex \
 			--require=asciidoctor-lists \
             --require=asciidoctor-mathematical
 
-.PHONY: all build clean build-container build-no-container build-docs arc-rename stamp-antora
+.PHONY: all build clean build-container build-no-container build-docs arc-rename stamp-antora set-mode
 
 all: build
+
+# Switch the template mode in place (reversible). Flips .docmode and reconciles
+# antora.yml's page-phase* block, then re-stamps. Use if the mode was set in
+# error at repo creation -- no need to recreate the repo. E.g. `make set-mode
+# MODE=doc`. No Docker needed; edits .docmode + antora.yml in place, commit both.
+set-mode:
+	@if [ -z "$(MODE)" ]; then echo "usage: make set-mode MODE=<spec|doc>" >&2; exit 2; fi
+	./scripts/set-mode.sh "$(MODE)"
 
 # Stamp antora.yml with the current VERSION/DATE so the Antora HTML site version
 # stays in EXACT lockstep with the ARC PDF (both derive from release-info.sh /

--- a/README.adoc
+++ b/README.adoc
@@ -6,7 +6,17 @@ NOTE: If you are viewing this in a specification repository, kindly update the t
 
 [IMPORTANT]
 ====
-**ARC submissions:** Specifications submitted to the Architecture Review Committee (ARC) must follow the conventions in link:ARC_SUBMISSION.md[ARC_SUBMISSION.md] — versioned GitHub tag, PDF named `<short>-v<X.Y.Z>-<YYYYMMDD>.pdf`, and a title page that matches. The Makefile and CI workflows in this template produce ARC-compliant artifacts on every build by default.
+**First step — choose your mode.** This template runs in one of two modes, set by the `.docmode` file at the repo root:
+
+* **`spec`** (default) — a ratified RISC-V specification on the ARC / Policies & Procedures process.
+* **`doc`** — non-ratified documentation (for example, a developer guide) that still needs the PDF, the Makefile HTML, and the Antora site, but none of the ratification layer: no milestone phases, no "Document State" page, no ARC submission.
+
+If you are standing up a **documentation** repo, set `.docmode` to `doc` now; leave it as `spec` for a specification. This one file switches the Makefile, the release scripts, and CI — authors never touch it. See link:ANTORA.md[ANTORA.md] "Template modes" for what each mode includes, and link:MIGRATION.md[MIGRATION.md] for the doc-mode migration checklist.
+====
+
+[IMPORTANT]
+====
+**ARC submissions (spec mode):** Specifications submitted to the Architecture Review Committee (ARC) must follow the conventions in link:ARC_SUBMISSION.md[ARC_SUBMISSION.md] — versioned GitHub tag, PDF named `<short>-v<X.Y.Z>-<YYYYMMDD>.pdf`, and a title page that matches. In `spec` mode (the default) the Makefile and CI workflows in this template produce ARC-compliant artifacts on every build.
 
 **Migrating an existing repo?** See link:MIGRATION.md[MIGRATION.md] for the step-by-step checklist to bring a downstream fork in line with the current toolchain — both the ARC submission PDF and the Antora site, which share one source tree. See link:ANTORA.md[ANTORA.md] for how that dual build works and why.
 ====

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -25,15 +25,20 @@ image::common::risc-v_logo.svg[id="riscvlogo",role="xs",alt="RISCV"]
 // Values come from antora.yml attributes stamped by scripts/stamp-antora-version.sh
 // from the same release-info.sh source the PDF uses, so this stays in lockstep
 // with the PDF title page. Do not hardcode a version here.
-Version {page-revnumber}, {page-revdate}: {page-phase-display}
+// Doc mode (non-ratified) carries no page-phase* attributes, so the milestone
+// suffix and the phase banner below are omitted.
+ifdef::page-phase-display[Version {page-revnumber}, {page-revdate}: {page-phase-display}]
+ifndef::page-phase-display[Version {page-revnumber}, {page-revdate}]
 
 // Phase/status banner mirrors the PDF's "Document State" preface: the label and
 // notice both track the current ARC phase via stamped attributes.
+ifdef::page-phase-notice[]
 [NOTE]
 .This document is in the link:http://riscv.org/spec-state[{page-phase-display} state]
 ====
 {page-phase-notice}
 ====
+endif::[]
 
 Replace this text with a short abstract of your specification and links into the
 chapters listed in the navigation. The same chapter sources under

--- a/scripts/release-info.sh
+++ b/scripts/release-info.sh
@@ -6,6 +6,18 @@ DEFAULT_PHASE="draft-and-development"
 SPEC_STATE_URL="http://riscv.org/spec-state"
 MAX_PATCH_BEFORE_MINOR_BUMP="${MAX_PATCH_BEFORE_MINOR_BUMP:-99}"
 
+# Template mode: "spec" (ratified, ARC/P&P milestones) or "doc" (non-ratified
+# documentation -- Antora-ready but no ratification layer). Selected once by the
+# committed .docmode file at the repo root; absent => "spec" (backward
+# compatible). In "doc" mode the phase/milestone surface below goes neutral --
+# the version scheme (semver tags + build date) is shared and unchanged.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Read the first non-blank, non-comment token so .docmode can self-document with
+# trailing `#` comments. Missing file or empty value => "spec" (safe default;
+# every reader treats a non-"doc" value as spec).
+DOC_MODE="${DOC_MODE:-$(awk 'NF && $1 !~ /^#/ { print $1; exit }' "$SCRIPT_DIR/../.docmode" 2>/dev/null || echo spec)}"
+doc_mode() { [[ "$DOC_MODE" == "doc" ]]; }
+
 usage() {
   cat <<'USAGE'
 Usage: scripts/release-info.sh [version|normalize|next|phase|phase-floor-version|display|milestone|notice|revremark|all] [value]
@@ -66,7 +78,8 @@ next_version() {
   read -r major minor patch <<<"$(parse_version "$1")"
 
   # Progress pre-1.0 development by rolling patch to the next minor at .99.
-  if (( major == 0 && minor < 99 && patch >= MAX_PATCH_BEFORE_MINOR_BUMP )); then
+  # Doc mode has no milestone semantics -- always a plain patch bump.
+  if ! doc_mode && (( major == 0 && minor < 99 && patch >= MAX_PATCH_BEFORE_MINOR_BUMP )); then
     minor=$((minor + 1))
     patch=0
   else
@@ -110,6 +123,7 @@ phase_display_for_phase() {
   # Title-case display label rendered on the PDF title page and in the body
   # NOTE admonition. The canonical (lowercase, hyphenated) ID stays usable for
   # filenames, scripts, and machine-readable consumers; this is the human form.
+  if doc_mode; then echo ""; return 0; fi
   case "$1" in
     "draft-and-development") echo "Draft and Development" ;;
     "development-complete")  echo "Development Complete"  ;;
@@ -124,6 +138,9 @@ phase_display_for_phase() {
 
 phase_for_version() {
   local v="$1"
+
+  # Non-ratified docs have no milestone gates: emit no phase.
+  if doc_mode; then echo ""; return 0; fi
 
   if ! version_valid "$v"; then
     echo "$DEFAULT_PHASE"
@@ -150,6 +167,7 @@ phase_for_version() {
 }
 
 milestone_for_phase() {
+  if doc_mode; then echo ""; return 0; fi
   case "$1" in
     "development-complete")
       echo "v0.6.x development-complete"
@@ -176,6 +194,7 @@ milestone_for_phase() {
 }
 
 phase_floor_version() {
+  if doc_mode; then echo ""; return 0; fi
   case "$1" in
     "draft-and-development")
       echo "v0.0.1"
@@ -206,6 +225,7 @@ phase_floor_version() {
 }
 
 notice_for_phase() {
+  if doc_mode; then echo ""; return 0; fi
   case "$1" in
     "draft-and-development"|"development-complete")
       echo "Assume everything is subject to change. At this stage, ideas, structures, and content are still evolving. Feedback and iteration are encouraged as nothing is final, and adjustments may be frequent."

--- a/scripts/set-mode.sh
+++ b/scripts/set-mode.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Switch this template's mode in place -- reversible, run either direction.
+#
+#   scripts/set-mode.sh <spec|doc>   (or: make set-mode MODE=doc)
+#
+# A mode is normally chosen once at repo creation via the committed .docmode
+# file. If it was chosen in error you do NOT need to recreate the repo: this
+# helper flips .docmode AND reconciles antora.yml so the two stay consistent,
+# because the two modes expect a different antora.yml shape:
+#   * spec mode needs the page-phase / page-phase-display / page-phase-notice
+#     cover attributes (stamped from the milestone phase).
+#   * doc mode has no phase, so those keys are absent.
+# After reconciling it re-stamps antora.yml via stamp-antora-version.sh.
+#
+# It does NOT touch content files (SPEC_STATE.md, ARC_SUBMISSION.md) or git tags
+# -- it prints a reminder instead. Commit the result like any other change.
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$here/.." && pwd)"
+docmode_file="$repo_root/.docmode"
+antora_yml="$repo_root/antora.yml"
+
+target="${1:-}"
+case "$target" in
+  spec | doc) ;;
+  *)
+    echo "usage: scripts/set-mode.sh <spec|doc>   (or: make set-mode MODE=doc)" >&2
+    exit 2
+    ;;
+esac
+
+current="$(awk 'NF && $1 !~ /^#/ { print $1; exit }' "$docmode_file" 2>/dev/null || echo spec)"
+echo "set-mode: $current -> $target"
+
+# --- 1. Flip .docmode's value line, preserving the comment block below it. -----
+tmp="$(mktemp)"
+awk -v t="$target" '
+  !done && NF && $1 !~ /^#/ { print t; done = 1; next }
+  { print }
+  END { if (!done) print t }
+' "$docmode_file" > "$tmp"
+mv "$tmp" "$docmode_file"
+
+# --- 2. Reconcile antora.yml page-phase* keys. --------------------------------
+has_phase() { grep -qE '^[[:space:]]*page-phase:' "$antora_yml"; }
+
+if [[ "$target" == "doc" ]]; then
+  if has_phase; then
+    echo "set-mode: removing page-phase* attributes from antora.yml"
+    tmp="$(mktemp)"
+    # Delete the three page-phase* key lines and any deeper-indented (wrapped)
+    # continuation lines -- mirrors stamp-antora-version.sh's indent handling.
+    awk '
+      drop == 1 {
+        if ($0 ~ /^[[:space:]]*$/ || $0 ~ /^[[:space:]]*#/) { drop = 0 }
+        else { match($0, /^[[:space:]]*/); if (RLENGTH > 4) next; drop = 0 }
+      }
+      /^    page-phase(-display|-notice)?:/ { drop = 1; next }
+      { print }
+    ' "$antora_yml" > "$tmp"
+    mv "$tmp" "$antora_yml"
+  else
+    echo "set-mode: antora.yml already has no page-phase* attributes"
+  fi
+else # spec
+  if has_phase; then
+    echo "set-mode: antora.yml already has page-phase* attributes"
+  else
+    echo "set-mode: inserting page-phase* attributes into antora.yml (after page-revdate)"
+    tmp="$(mktemp)"
+    # Insert placeholders after page-revdate; the stamp below fills real values.
+    awk '
+      { print }
+      /^    page-revdate:/ {
+        print "    page-phase: draft-and-development"
+        print "    page-phase-display: '\''Draft'\''"
+        print "    page-phase-notice: '\''Placeholder -- stamped by set-mode.'\''"
+      }
+    ' "$antora_yml" > "$tmp"
+    mv "$tmp" "$antora_yml"
+  fi
+fi
+
+# --- 3. Re-stamp antora.yml in the new mode so values are consistent. ---------
+echo "set-mode: re-stamping antora.yml"
+DOC_MODE="$target" "$here/stamp-antora-version.sh"
+
+# --- 4. Remind about the non-antora bits this helper deliberately leaves alone.
+echo
+echo "set-mode: now in '$target' mode. Review and commit .docmode + antora.yml."
+if [[ "$target" == "doc" ]]; then
+  echo "  Note: SPEC_STATE.md / ARC_SUBMISSION.md are spec-only; delete them if unused."
+else
+  echo "  Note: ensure SPEC_STATE.md / ARC_SUBMISSION.md are present for ARC (they ship in the template)."
+fi

--- a/scripts/set-mode.sh
+++ b/scripts/set-mode.sh
@@ -43,6 +43,12 @@ awk -v t="$target" '
 mv "$tmp" "$docmode_file"
 
 # --- 2. Reconcile antora.yml page-phase* keys. --------------------------------
+# FRAGILE: the awk below assumes the template's 4-space antora.yml indentation
+# for the page-phase* block -- the `/^    page-phase.../` anchors and the
+# `RLENGTH > 4` wrapped-continuation test both hard-code that depth (matching
+# stamp-antora-version.sh). If antora.yml is ever reindented (2-space, tabs),
+# update those anchors here and in stamp-antora-version.sh together. The CI
+# doc-mode smoke job (build-pdf.yml) round-trips this script to catch drift.
 has_phase() { grep -qE '^[[:space:]]*page-phase:' "$antora_yml"; }
 
 if [[ "$target" == "doc" ]]; then

--- a/scripts/stamp-antora-version.sh
+++ b/scripts/stamp-antora-version.sh
@@ -21,6 +21,10 @@ here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "$here/.." && pwd)"
 antora_yml="$repo_root/antora.yml"
 
+# Template mode (spec|doc); see .docmode. In doc mode antora.yml carries no
+# page-phase* keys, so only version/revnumber/revdate are stamped and required.
+DOC_MODE="${DOC_MODE:-$(awk 'NF && $1 !~ /^#/ { print $1; exit }' "$repo_root/.docmode" 2>/dev/null || echo spec)}"
+
 version="${1:-$("$here/release-info.sh" version)}"
 date="${2:-$(date +%Y-%m-%d)}"
 
@@ -55,8 +59,13 @@ tmp="$(mktemp)"
 # Each key must be found EXACTLY once; otherwise we would exit 0 having stamped
 # nothing (or having stamped twice), and the release workflow's `git diff` check
 # would read that as "already up to date". Fail loudly instead -- see END.
-awk '
-  BEGIN { cont = -1; split("version revnumber revdate display notice phase", req, " ") }
+awk -v mode="$DOC_MODE" '
+  BEGIN {
+    cont = -1
+    # Doc mode has no phase keys; require only the version/date trio.
+    if (mode == "doc") nreq = split("version revnumber revdate", req, " ")
+    else               nreq = split("version revnumber revdate display notice phase", req, " ")
+  }
 
   cont >= 0 {
     if ($0 ~ /^[[:space:]]*$/ || $0 ~ /^[[:space:]]*#/) {
@@ -78,7 +87,7 @@ awk '
 
   END {
     bad = ""
-    for (i = 1; i <= 6; i++)
+    for (i = 1; i <= nreq; i++)
       if (seen[req[i]] != 1)
         bad = bad sprintf("  %-12s found %d time(s), expected 1\n", req[i], seen[req[i]] + 0)
     if (bad != "") {

--- a/src/spec-sample.adoc
+++ b/src/spec-sample.adoc
@@ -6,7 +6,12 @@ ifndef::revdate[:revdate: 1/2023]
 ifndef::phase[:phase: draft-and-development]
 ifndef::phase_display[:phase_display: {phase}]
 ifndef::phase_notice[:phase_notice: Assume everything is subject to change. At this stage, ideas, structures, and content are still evolving. Feedback and iteration are encouraged as nothing is final, and adjustments may be frequent.]
+// The default revremark is a ratification (spec-state) message. In doc mode the
+// Makefile sets the `doc-mode` attribute and passes an empty revremark, so this
+// spec-only default is suppressed.
+ifndef::doc-mode[]
 ifndef::revremark[:revremark: This document is under development. Expect potential changes. Visit http://riscv.org/spec-state for further details.]
+endif::[]
 ifndef::milestone_id[:milestone_id: {phase}]
 ifndef::spec_short[:spec_short: spec-sample]
 :docgroup: RISC-V Task Group
@@ -46,9 +51,12 @@ endif::[]
 
 // "Document State" preface is the phase Note rendered as page 2 of the PDF
 // (TOC is placed after it via the toc::[] macro below). See ARC_SUBMISSION.md §3.3.
+// Ratification-only: doc mode (non-ratified) omits it via the `doc-mode` attr.
+ifndef::doc-mode[]
 [preface]
 == Document State
 *Note:* {phase_notice}
+endif::[]
 
 toc::[]
 


### PR DESCRIPTION
## Summary

Adds a first-class **mode switch** so `docs-spec-template` can serve non-ratified
RISC-V documentation (e.g. [`docs-dev-guide`](https://github.com/riscv/docs-dev-guide))
as well as ratified specifications. A single committed `.docmode` file selects
`spec` (today's behavior, **byte-for-byte**) or `doc`. Absent ⇒ `spec`, so every
existing spec repo is unaffected.

`doc` mode keeps the ARC-form PDF, the Makefile HTML target, and the Antora site,
but strips the ratification layer: no milestone phases, no "Document State"
preface, no spec-state cover banner, no milestone version-bot PRs.

Closes #110.

## How it works

`.docmode` (self-documenting: value on line 1, `#` comments below) is read by
`release-info.sh`, the `Makefile`, `stamp-antora-version.sh`, and CI — each parses
the first non-comment token, so a missing/empty file resolves to `spec`.

| Concern | spec (default) | doc |
|---|---|---|
| ARC-form PDF / Makefile HTML / Antora site | ✅ | ✅ |
| Version scheme | semver tags → milestone phase gates | semver tags + build date, no phases |
| "Document State" preface + spec-state banner | ✅ | ❌ omitted |
| Milestone version-bot / milestone PRs | ✅ | ❌ inert (plain patch bumps) |
| `SPEC_STATE.md`, `ARC_SUBMISSION.md` | apply | not used |

## Discoverability & reversibility

- **README.adoc** gains a "First step — choose your mode" setup callout (the admin
  creating the repo sees it), and `.docmode` self-documents.
- **`make set-mode MODE=<spec|doc>`** switches an existing repo in place — flips
  `.docmode` and reconciles `antora.yml`'s `page-phase*` block, then re-stamps. A
  mis-selection is a reversible PR, not a repo recreation.

## Files

`.docmode` (new), `scripts/set-mode.sh` (new), `scripts/release-info.sh`,
`scripts/stamp-antora-version.sh`, `Makefile`, `src/spec-sample.adoc`,
`modules/ROOT/pages/index.adoc`, `.github/workflows/{build-pdf,version-bot}.yml`,
`README.adoc`, `ANTORA.md`, `MIGRATION.md`.

## Verification (local, both modes)

- **spec-mode regression:** `release-info.sh all` output and a re-stamp of
  `antora.yml` are identical to `main`; PDF still renders "Document State".
- **doc mode:** PDF **and** Makefile HTML build clean and omit "Document State";
  cover renders with no phase banner and no trailing `: <display>`.
- **stamp:** doc-mode descriptor (no `page-phase*`) stamps cleanly; spec-mode
  stamp on a phase-less file fails loudly (exit 3) rather than silently.
- **set-mode:** round-trips `spec↔doc` idempotently; `MODE` guards fire.
- `pre-commit` hooks pass; `bash -n` clean.

## Out of scope

Migrating the real `docs-dev-guide` repo — that lands as a separate PR in that
repo; it is the worked example in `MIGRATION.md` here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
