### PR TITLE
Move to 2-digit decimal versioning

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       release_version:
-        description: Override version (e.g., v0.8.2). Milestone floors become official releases.
+        description: Override version (e.g., v0.62). Milestone floors become official releases.
         required: false
         type: string
       target_phase:
@@ -21,7 +21,6 @@ on:
           - stabilized
           - frozen
           - ratification-ready
-          - publication
           - ratified
       draft:
         description: Create release as a draft?
@@ -62,30 +61,40 @@ jobs:
         id: set_build_version
         run: |
           set -euo pipefail
+
+          # Auto-increment (`next`) refuses at a milestone gate with rc=10 (the
+          # 0.01 band before the next manual milestone is exhausted). For a
+          # preview/non-release build that is not fatal: fall back to rebuilding
+          # the latest tag rather than failing the run.
+          next_or_latest() {
+            local base="$1" out
+            if out="$(./scripts/release-info.sh next "$base" 2>/dev/null)"; then
+              printf '%s\n' "$out"
+            else
+              printf '%s\n' "$base"
+            fi
+          }
+
           if [ -n "${{ github.event.inputs.release_version }}" ]; then
-            version="${{ github.event.inputs.release_version }}"
+            version="$(./scripts/release-info.sh normalize "${{ github.event.inputs.release_version }}")"
           elif [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.event.inputs.target_phase }}" != "auto-next" ]; then
             version="$(./scripts/release-info.sh phase-floor-version "${{ github.event.inputs.target_phase }}")"
           elif [ "${{ github.ref_type }}" = "tag" ]; then
-            version="${{ github.ref_name }}"
+            version="$(./scripts/release-info.sh normalize "${{ github.ref_name }}")"
           elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            latest="$(./scripts/release-info.sh version)"
+            latest="$(./scripts/release-info.sh latest)"
             latest_phase="$(./scripts/release-info.sh phase "$latest")"
             latest_floor="$(./scripts/release-info.sh phase-floor-version "$latest_phase")"
-            if [ "$latest" != "v0.0.0" ] && [ "$latest" != "$latest_floor" ]; then
+            if [ "$latest" != "v0.0" ] && [ "$latest" != "$latest_floor" ]; then
               # If current tag is between milestone floors, rebuild/re-release current latest tag.
               version="$latest"
             else
-              version="$(./scripts/release-info.sh next "$latest")"
+              version="$(next_or_latest "$latest")"
             fi
           else
-            latest="$(./scripts/release-info.sh version)"
-            version="$(./scripts/release-info.sh next "$latest")"
+            latest="$(./scripts/release-info.sh latest)"
+            version="$(next_or_latest "$latest")"
           fi
-          case "$version" in
-            v*) ;;
-            *) version="v$version" ;;
-          esac
           # Resolve the build date ONCE so the PDF and the Antora version stamp
           # share it exactly (no midnight-boundary drift between separate steps).
           date="$(date +%Y-%m-%d)"
@@ -97,16 +106,14 @@ jobs:
       - name: Classify release type
         run: |
           set -euo pipefail
-          # Milestone-gate tags get a non-prerelease GitHub Release.
-          # v0.99.1 is the entry into publication, so it is also considered official.
-          case "${VERSION}" in
-            v0.6.0|v0.8.0|v0.9.0|v0.99.0|v0.99.1|v1.0.0)
-              echo "OFFICIAL_RELEASE=true" >> "$GITHUB_ENV"
-              ;;
-            *)
-              echo "OFFICIAL_RELEASE=false" >> "$GITHUB_ENV"
-              ;;
-          esac
+          # Milestone-gate tags (v0.6, v0.8, v0.9, v0.99, v1.0) get a
+          # non-prerelease GitHub Release. release-info.sh is the single source of
+          # truth for which versions are milestones.
+          if ./scripts/release-info.sh is-milestone "${VERSION}"; then
+            echo "OFFICIAL_RELEASE=true" >> "$GITHUB_ENV"
+          else
+            echo "OFFICIAL_RELEASE=false" >> "$GITHUB_ENV"
+          fi
 
       # Build Files. VERSION and DATE are exported so the Makefile and
       # release-info.sh produce ARC-compliant PDF names: <short>-v<ver>-<YYYYMMDD>.pdf
@@ -224,10 +231,11 @@ jobs:
 
           # Monotonic guard: never stamp main backwards (e.g. when an old tag is
           # rebuilt). Skip if main is already at a version >= this release.
+          # Compare by DECIMAL order via release-info.sh -- `sort -V` would rank
+          # v0.8 below v0.61 and stamp the site backwards.
           if [ -n "$current" ] && [ "$current" != "~" ] && [ "$current" != "$VERSION" ]; then
-            highest="$(printf '%s\n%s\n' "${current#v}" "${VERSION#v}" | sort -V | tail -n1)"
-            if [ "$highest" = "${current#v}" ]; then
-              echo "main is already at $current (>= $VERSION); skipping stamp."
+            if [ "$(./scripts/release-info.sh compare "$current" "$VERSION")" = "1" ]; then
+              echo "main is already at $current (> $VERSION); skipping stamp."
               echo "changed=false" >> "$GITHUB_OUTPUT"
               exit 0
             fi

--- a/.github/workflows/version-bot.yml
+++ b/.github/workflows/version-bot.yml
@@ -21,10 +21,9 @@ on:
           - stabilized
           - frozen
           - ratification-ready
-          - publication
           - ratified
       release_version:
-        description: Explicit version override (e.g., v0.9.0). If set, target_phase is ignored.
+        description: Explicit version override (e.g., v0.9). If set, target_phase is ignored.
         required: false
         type: string
       allow_non_monotonic:
@@ -66,8 +65,33 @@ jobs:
 
           git fetch --tags --force
 
-          latest="$(git tag --list 'v*' --sort=-version:refname | head -n1 || true)"
-          latest="${latest:-v0.0.0}"
+          # Highest existing tag by DECIMAL order. Never use `git ... --sort` or
+          # `sort -V` here: they order the fractional part component-wise and rank
+          # v0.8 below v0.61. release-info.sh compares by centi-value.
+          latest="$(./scripts/release-info.sh latest)"
+
+          # Auto-increment (`next`) refuses at a milestone gate with rc=10: the
+          # 0.01 band before the next manual milestone is exhausted. That is not
+          # an error -- it means "a maintainer must cut the milestone" -- so we
+          # emit a notice and finish without tagging. Sets the global `next`;
+          # returns non-zero (band exhausted) to signal "stop, no tag". Kept out
+          # of $(...) so the ::notice:: reaches the workflow log.
+          compute_next() {
+            local base="$1" out rc
+            # Capture rc from the substitution itself (a bare `if ...; fi` with no
+            # else would leave $? as the if-statement's 0, masking rc=10).
+            out="$(./scripts/release-info.sh next "$base" 2>/tmp/next.err)" && rc=0 || rc=$?
+            if [[ "$rc" -eq 0 ]]; then
+              next="$out"
+              return 0
+            fi
+            if [[ "$rc" -eq 10 ]]; then
+              echo "::notice::$(cat /tmp/next.err) No tag created."
+              return 1
+            fi
+            cat /tmp/next.err >&2
+            exit "$rc"
+          }
 
           if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
             if [[ "$REF_NAME" != "main" ]]; then
@@ -80,20 +104,19 @@ jobs:
             elif [[ -n "${TARGET_PHASE:-}" && "$TARGET_PHASE" != "auto-next" ]]; then
               next="$(./scripts/release-info.sh phase-floor-version "$TARGET_PHASE")"
             else
-              next="$(./scripts/release-info.sh next "$latest")"
+              compute_next "$latest" || exit 0
             fi
           else
             existing="$(git tag --points-at HEAD --list 'v*' | head -n1 || true)"
             if [[ -n "$existing" ]]; then
-              next="$existing"
+              next="$(./scripts/release-info.sh normalize "$existing")"
             else
-              next="$(./scripts/release-info.sh next "$latest")"
+              compute_next "$latest" || exit 0
             fi
           fi
 
           if [[ "${ALLOW_NON_MONOTONIC:-false}" != "true" ]]; then
-            highest="$(printf '%s\n%s\n' "${latest#v}" "${next#v}" | sort -V | tail -n1)"
-            if [[ "$highest" != "${next#v}" ]]; then
+            if [[ "$(./scripts/release-info.sh compare "$next" "$latest")" == "-1" ]]; then
               echo "Refusing non-monotonic jump from $latest to $next. Set allow_non_monotonic=true to override." >&2
               exit 1
             fi

--- a/ANTORA.md
+++ b/ANTORA.md
@@ -181,7 +181,7 @@ unnumbered back matter).
   attributes configure (kroki, mathjax, ASAM bib) land in Phase 5, so the
   attributes are inert in bare local preview until then.
 - [x] **Phase 4 — Version bridge.** The ARC Author Guide requires the artifact's
-  identity to be the `vX.Y.Z` release tag; the HTML site version must match the
+  identity to be the `vX.Y` release tag; the HTML site version must match the
   PDF version exactly. Because Antora reads a STATIC `version:` from the committed
   `antora.yml` (the central playbook just fetches the branch — no build step runs
   `release-info.sh` on the spec side), the bridge *stamps* that file, the Antora
@@ -196,12 +196,12 @@ unnumbered back matter).
   * `index.adoc` cover renders the PDF title-page revision line verbatim:
     `Version {page-revnumber}, {page-revdate}: {page-phase-display}`, plus a phase
     banner mirroring the PDF "Document State" preface. No hardcoded version.
-  * Verified: stamping `v0.8.0` yields `/spec-sample/v0.8.0/` with cover
-    "Version v0.8.0, 2026-06-12: Stabilized"; restamped to the repo's real state.
+  * Verified: stamping `v0.8` yields `/spec-sample/v0.8/` with cover
+    "Version v0.8, 2026-06-12: Stabilized"; restamped to the repo's real state.
   * **Release step:** automated in `build-pdf.yml` (see Phase 6) — the same run
     that builds the PDF stamps the matching version and opens a review PR against
     `main`; merging it is part of cutting a release. Manual fallback for
-    local/offline releases: `make stamp-antora VERSION=vX.Y.Z` then commit
+    local/offline releases: `make stamp-antora VERSION=vX.Y` then commit
     `antora.yml`.
   * **Hardening:** the stamp script asserts that each key was substituted exactly
     once and that the result still parses as YAML, then fails loudly. It
@@ -264,7 +264,7 @@ unnumbered back matter).
 
 ```bash
 make                          # ARC PDF (+ HTML) via Docker; VERSION/DATE overridable
-make stamp-antora VERSION=vX.Y.Z   # stamp antora.yml to match the PDF release (commit the result)
+make stamp-antora VERSION=vX.Y   # stamp antora.yml to match the PDF release (commit the result)
 
 # Local Antora preview (renders like production: diagrams + math):
 npm install                   # one-time: Antora + kroki/mathjax extensions

--- a/ARC_SUBMISSION.md
+++ b/ARC_SUBMISSION.md
@@ -55,7 +55,7 @@ Every specification submitted to ARC for review MUST be presented as:
    - the version string matching the tag, and
    - a date stamp in `YYYYMMDD` form.
 
-   Pattern: `<spec-short-name>-v<X.Y.Z>-<YYYYMMDD>.pdf`
+   Pattern: `<spec-short-name>-v<MAJOR>.<MINOR>-<YYYYMMDD>.pdf`
 
 4. **The PDF title page MUST display the same information** — spec name,
    version string, milestone ID, and date — and they MUST match the filename
@@ -65,43 +65,47 @@ Every specification submitted to ARC for review MUST be presented as:
 
 ### 3.1 Version → Milestone mapping
 
-Tags use **`vMAJOR.MINOR.PATCH`** semver form. The `MAJOR.MINOR` pair encodes
-the milestone; `PATCH` is the revision within that milestone band. The
-milestone ID is the single canonical label that identifies what state the
-document is in.
+Tags use **`vMAJOR.MINOR`** form, where the version is a fixed-point decimal to
+hundredths: `v0.6` = 0.60, `v0.72` = 0.72, `v1.0` = 1.00. Ordering is therefore
+**decimal, not semver** — `v0.8` (0.80) is greater than `v0.61`. The milestone
+gates are the reserved values below; between them, merges to `main`
+auto-advance the revision by `0.01` (`v0.61`, `v0.62`, …). The milestone ID is
+the single canonical label that identifies what state the document is in.
 
 | Milestone ID            | Tag at milestone gate | Revisions within phase     |
 | ----------------------- | --------------------- | -------------------------- |
-| `development-complete`  | `v0.6.0`              | `v0.6.1`, `v0.6.2`, …      |
-| `stabilized`            | `v0.8.0`              | `v0.8.1`, `v0.8.2`, …      |
-| `frozen`                | `v0.9.0`              | `v0.9.1`, `v0.9.2`, …      |
-| `ratification-ready`    | `v0.99.0`             | (no patches; single tag)   |
-| `publication`           | `v0.99.1`             | `v0.99.2`, `v0.99.3`, …    |
-| `ratified`              | `v1.0.0`              | `v1.0.1`, … (errata)       |
+| `development-complete`  | `v0.6`                | `v0.61`, `v0.62`, … `v0.79` |
+| `stabilized`            | `v0.8`                | `v0.81`, `v0.82`, … `v0.89` |
+| `frozen`                | `v0.9`                | `v0.91`, `v0.92`, … `v0.98` |
+| `ratification-ready`    | `v0.99`               | (no revisions; single tag) |
+| `ratified`              | `v1.0`                | (no revisions; ratified)   |
 
-**Tags MUST be monotonically increasing.** Never delete or rewrite a
-published tag — create a new one.
+Milestone gates are cut **manually** by a maintainer; the `v0.NN` revisions
+between them are created automatically on merge to `main`. `v0.0` is the
+inception version.
+
+**Tags MUST be monotonically increasing** (by decimal value). Never delete or
+rewrite a published tag — create a new one.
 
 A revision tag carries the milestone label of the **most recent gate
-passed**. Example: `v0.8.3` is still labeled `stabilized` until the spec is
-re-tagged at `v0.9.0` (`frozen`).
+passed**. Example: `v0.83` is still labeled `stabilized` until the spec is
+re-tagged at `v0.9` (`frozen`).
 
 ### 3.2 PDF filename
 
 ```
-<spec-short-name>-v<MAJOR>.<MINOR>.<PATCH>-<YYYYMMDD>.pdf
+<spec-short-name>-v<MAJOR>.<MINOR>-<YYYYMMDD>.pdf
 ```
 
 Worked examples — one per milestone:
 
 | Filename                                | Milestone            |
 | --------------------------------------- | -------------------- |
-| `Zifoo-v0.6.0-20260520.pdf`             | development-complete |
-| `Zifoo-v0.8.0-20260612.pdf`             | stabilized           |
-| `RHTI-v0.9.0-20260408.pdf`              | frozen               |
-| `Server-Platform-v0.99.0-20260415.pdf`  | ratification-ready   |
-| `Server-Platform-v0.99.1-20260520.pdf`  | publication          |
-| `Zifoo-v1.0.0-20260901.pdf`             | ratified             |
+| `Zifoo-v0.6-20260520.pdf`               | development-complete |
+| `Zifoo-v0.8-20260612.pdf`               | stabilized           |
+| `RHTI-v0.9-20260408.pdf`                | frozen               |
+| `Server-Platform-v0.99-20260415.pdf`    | ratification-ready   |
+| `Zifoo-v1.0-20260901.pdf`               | ratified             |
 
 Use the **short name** registered for the spec, not the long title. Use
 hyphens, not spaces.
@@ -111,7 +115,7 @@ hyphens, not spaces.
 The first page of the PDF MUST show, prominently:
 
 - Spec long title and short name
-- Full semver version string matching the tag and filename (e.g. `v0.8.0`)
+- Version string matching the tag and filename (e.g. `v0.8`)
 - Date in human-readable form matching the `YYYYMMDD` in the filename
 - **Milestone label**, the title-case display form of one of the canonical
   milestone IDs:
@@ -123,7 +127,6 @@ The first page of the PDF MUST show, prominently:
   | `stabilized`                      | Stabilized                 |
   | `frozen`                          | Frozen                     |
   | `ratification-ready`              | Ratification-Ready         |
-  | `publication`                     | Publication                |
   | `ratified`                        | Ratified                   |
 
 The canonical ID is what scripts, filenames, and CI consumers reference.
@@ -132,8 +135,8 @@ The display label is what humans see on the title page.
 Repos derived from `docs-spec-template` get this layout automatically:
 
 - **Page 1 (title page):** title, authors, and a single revision line of the
-  form `Version vX.Y.Z, YYYY-MM-DD: <Milestone display label>` — for
-  example `Version v1.0.0, 2026-05-24: Ratified`. This is asciidoctor-pdf's
+  form `Version vX.Y, YYYY-MM-DD: <Milestone display label>` — for
+  example `Version v1.0, 2026-05-24: Ratified`. This is asciidoctor-pdf's
   default rendering of `revnumber, revdate: revremark`, with `revremark`
   set to the title-case display label.
 
@@ -164,9 +167,9 @@ toc::[]
 1. Freeze the source at the commit you intend to submit.
 2. Run the `Create Specification Document` GitHub Action with
    `target_phase` set to the milestone you're cutting (e.g. `stabilized`)
-   — OR push a tag of the form `v0.8.0`.
+   — OR push a tag of the form `v0.8`.
 3. The workflow builds the PDF with `VERSION` and `DATE` plumbed through
-   the Makefile, produces `build/<short>-v<X.Y.Z>-<YYYYMMDD>.pdf`, creates
+   the Makefile, produces `build/<short>-v<MAJOR>.<MINOR>-<YYYYMMDD>.pdf`, creates
    a GitHub Release, and attaches the PDF.
 4. Verify the title page shows the version, milestone ID, and date.
 5. Use the **GitHub Release URL** when scheduling the ARC slot.
@@ -174,9 +177,9 @@ toc::[]
 ### 4.2 Building locally
 
 ```bash
-make VERSION=v0.8.0 DATE=2026-06-12
+make VERSION=v0.8 DATE=2026-06-12
 ls build/
-# → <short>-v0.8.0-20260612.pdf
+# → <short>-v0.8-20260612.pdf
 ```
 
 The `arc-rename` target in the Makefile produces the ARC-compliant filename
@@ -194,16 +197,17 @@ basenames are the ARC short names.
 
 Before requesting an ARC review slot, confirm:
 
-- [ ] Tag `v<X>.<Y>.<Z>` is pushed to the canonical repo
+- [ ] Tag `v<MAJOR>.<MINOR>` is pushed to the canonical repo
 - [ ] Tag is on a commit that builds reproducibly
 - [ ] PDF is published (release asset preferred) with filename
-      `<short>-v<X>.<Y>.<Z>-<YYYYMMDD>.pdf`
+      `<short>-v<MAJOR>.<MINOR>-<YYYYMMDD>.pdf`
 - [ ] PDF title page shows the same short name, version, milestone ID, and
       date
 - [ ] The version and date in filename, tag, title page, and milestone ID
       are mutually consistent (no `v0.85` filename with a `frozen`
       milestone, etc.)
-- [ ] Tag version is monotonically greater than the previous tag
+- [ ] Tag version is monotonically greater than the previous tag (decimal
+      order: `v0.8` > `v0.79`)
 
 ARC reviewers reference the **tag link** (or release URL), not a draft or
 branch. Submissions that don't satisfy the checklist will be rejected and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,25 +7,26 @@ As an open-source project, we appreciate and encourage community members to subm
 Specification version/state metadata is managed by CI.
 
 - Pushes to `main` that modify `src/**` trigger the version bot workflow.
-- The bot creates the next patch tag (`vX.Y.Z`) from the latest existing `v*` tag.
+- Versions are two-digit `vMAJOR.MINOR` as a fixed-point decimal (`v0.6` = 0.60, `v0.72` = 0.72, `v1.0` = 1.00). Ordering is decimal, not semver: `v0.8` (0.80) is greater than `v0.61`.
+- The bot advances the revision by `0.01` (`v0.61` -> `v0.62`) from the latest existing `v*` tag.
 - Tag creation triggers the document build workflow, which sets `:revnumber:` and `:revdate:` during build.
 - Phase/state text (`:phase:`, `:phase_display:`, `:phase_notice:`, and `:revremark:`) is derived from the version via `scripts/release-info.sh`.
-- Pre-1.0 rollover rule: `v0.B.99` rolls to `v0.(B+1).0` for `B < 99` (for example `v0.0.99` -> `v0.1.0`).
+- Milestone gates (`v0.6`, `v0.8`, `v0.9`, `v0.99`, `v1.0`) are cut **manually** — the bot never auto-advances onto a gate. When the auto band is exhausted (for example at `v0.79`), a maintainer cuts the next milestone.
 - Manual force-jump is available via `workflow_dispatch` in `.github/workflows/version-bot.yml`.
-- Use `target_phase` to jump to a milestone floor (for example `Frozen` -> `v0.9.0`).
+- Use `target_phase` to jump to a milestone floor (for example `Frozen` -> `v0.9`).
 - Use `release_version` to set a specific version directly (this overrides `target_phase`).
 - Manual runs must target `main`.
 - Backward jumps are blocked by default; use `allow_non_monotonic=true` only when intentionally overriding this safety check.
-- Official release policy: only `v0.6.0`, `v0.8.0`, `v0.9.0`, `v0.99.0`, and `v1.0.0` are published as official (`prerelease=false`).
+- Official release policy: only `v0.6`, `v0.8`, `v0.9`, `v0.99`, and `v1.0` are published as official (`prerelease=false`).
 - Every other version is published as a prerelease (`prerelease=true`).
 
 Milestone boundaries are:
 
-- `v0.6.x`: Developed
-- `v0.8.x`: Stable
-- `v0.9.x`: Frozen
-- `v0.99.x`: Ratification-Ready
-- `v1.0.0`: Ratified
+- `v0.6`: Developed (revisions `v0.61`–`v0.79`)
+- `v0.8`: Stable (revisions `v0.81`–`v0.89`)
+- `v0.9`: Frozen (revisions `v0.91`–`v0.98`)
+- `v0.99`: Ratification-Ready
+- `v1.0`: Ratified
 
 When a new version crosses a milestone boundary, CI opens a PR that updates `SPEC_STATE.md` for maintainer review.
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -9,9 +9,9 @@ forked from `docs-spec-template` or shares its toolchain (Makefile +
 source tree, and a spec author needs both:
 
 1. **The ARC submission PDF.** ARC rejects submissions that do not emit a PDF
-   named `<short>-v<X.Y.Z>-<YYYYMMDD>.pdf` whose title page matches, using six
-   canonical milestone IDs (`development-complete`, `stabilized`, `frozen`,
-   `ratification-ready`, `publication`, `ratified`).
+   named `<short>-v<MAJOR>.<MINOR>-<YYYYMMDD>.pdf` whose title page matches,
+   using the canonical milestone IDs (`development-complete`, `stabilized`,
+   `frozen`, `ratification-ready`, `ratified`).
 2. **The Antora HTML site.** Chapter content is consumed as a *content source*
    by the RISC-V central playbook and published on antora.riscv.org. The ARC
    Author Guide requires the site version to match the PDF version **exactly**.
@@ -30,8 +30,9 @@ is the sequence of actions; ANTORA.md is the rationale.
 - [ ] Skim `ANTORA.md` §"The dual-source technique" and §"Production model".
 - [ ] Confirm your repo's spec short name (e.g. `Zifoo`, `Server-Platform`,
       `RHTI`). This is the `<spec-short>` that appears in PDF filenames.
-- [ ] Check the latest tag in your repo (`git tag --list 'v*' --sort=-version:refname | head -1`).
-      Your next tag MUST be monotonically greater.
+- [ ] Check the latest tag in your repo (`./scripts/release-info.sh latest`).
+      Your next tag MUST be monotonically greater (decimal order: `v0.8` > `v0.79`).
+      Do NOT use `git ... --sort=version:refname` — it ranks `v0.8` below `v0.61`.
 - [ ] **Do NOT rewrite or delete existing tags.** The policy is
       forward-looking; old artifacts stay as-is.
 
@@ -51,14 +52,19 @@ Replace your script with the upstream version, or apply the following changes:
 
 - [ ] Phase IDs switched from `Developed`/`Stable`/`Frozen`/`Ratification-Ready`/`Ratified`
       to the canonical (lowercase, hyphenated) IDs
-      `development-complete`/`stabilized`/`frozen`/`ratification-ready`/`publication`/`ratified`.
-- [ ] New `publication` band added at `v0.99.1+` (between `ratification-ready`
-      at `v0.99.0` and `ratified` at `v1.0.0`).
+      `development-complete`/`stabilized`/`frozen`/`ratification-ready`/`ratified`.
+- [ ] Versions are two-digit `vMAJOR.MINOR` as a fixed-point decimal
+      (`v0.6` = 0.60, `v1.0` = 1.00). Comparison is decimal, not semver, so the
+      script compares by centi-value — never `sort -V`/`git ... --sort`, which
+      rank `v0.8` below `v0.61`. Use the `compare`/`max`/`latest` subcommands.
+- [ ] Milestone gates are `v0.6`, `v0.8`, `v0.9`, `v0.99`, `v1.0`. `next`
+      advances by `0.01` and REFUSES (exit 10) when the next step would land on
+      a gate — gates are cut manually via `workflow_dispatch`.
 - [ ] New helper `phase_display_for_phase` returns the title-case display
       label (e.g. `Stabilized`, `Ratification-Ready`) used on the title page.
 - [ ] `revremark_for_phase` is now a thin wrapper that returns just the
       display label (e.g. `"Ratified"`), so asciidoctor-pdf renders
-      `Version vX.Y.Z, YYYY-MM-DD: <Label>` on the title page.
+      `Version vX.Y, YYYY-MM-DD: <Label>` on the title page.
 - [ ] `display` CLI command returns the display label (title-case), not the
       canonical ID.
 - [ ] `notice_for_phase`, `phase_floor_version`, `milestone_for_phase` all
@@ -70,7 +76,7 @@ the PDF build and the Antora version stamp (Step 12) both call it. Sync it first
 
 Smoke test:
 ```bash
-for v in v0.5.0 v0.6.0 v0.7.3 v0.8.0 v0.9.0 v0.99.0 v0.99.1 v1.0.0; do
+for v in v0.5 v0.6 v0.73 v0.8 v0.9 v0.99 v1.0; do
   printf "%-10s phase=%-22s display=%s\n" "$v" \
     "$(./scripts/release-info.sh phase $v)" \
     "$(./scripts/release-info.sh display $v)"
@@ -78,14 +84,13 @@ done
 ```
 Expected:
 ```
-v0.5.0     phase=draft-and-development  display=Draft and Development
-v0.6.0     phase=development-complete   display=Development Complete
-v0.7.3     phase=development-complete   display=Development Complete
-v0.8.0     phase=stabilized             display=Stabilized
-v0.9.0     phase=frozen                 display=Frozen
-v0.99.0    phase=ratification-ready     display=Ratification-Ready
-v0.99.1    phase=publication            display=Publication
-v1.0.0     phase=ratified               display=Ratified
+v0.5       phase=draft-and-development  display=Draft and Development
+v0.6       phase=development-complete   display=Development Complete
+v0.73      phase=development-complete   display=Development Complete
+v0.8       phase=stabilized             display=Stabilized
+v0.9       phase=frozen                 display=Frozen
+v0.99      phase=ratification-ready     display=Ratification-Ready
+v1.0       phase=ratified               display=Ratified
 ```
 
 ## Step 2 — Update `Makefile`
@@ -139,13 +144,14 @@ v1.0.0     phase=ratified               display=Ratified
 
 Smoke test (no Docker required):
 ```bash
-make -n SKIP_DOCKER=true VERSION=v0.8.0 DATE=2026-06-12 | grep -E "(asciidoctor|ARC|dest=)"
+make -n SKIP_DOCKER=true VERSION=v0.8 DATE=2026-06-12 | grep -E "(asciidoctor|ARC|dest=)"
 ```
-Should show `dest="<short>-v0.8.0-20260612.pdf"`.
+Should show `dest="<short>-v0.8-20260612.pdf"`.
 
 ## Step 3 — Update `.github/workflows/build-pdf.yml`
 
-- [ ] Replace `target_phase` enum values with the canonical IDs:
+- [ ] Replace `target_phase` enum values with the canonical IDs (no
+      `publication` — it is a phase, not a milestone version):
       ```yaml
       options:
         - auto-next
@@ -154,18 +160,17 @@ Should show `dest="<short>-v0.8.0-20260612.pdf"`.
         - stabilized
         - frozen
         - ratification-ready
-        - publication
         - ratified
       ```
-- [ ] Add `v0.99.1` to the `OFFICIAL_RELEASE` case statement so entry into
-      publication is treated as an official release:
+- [ ] Classify official releases via `release-info.sh is-milestone` (the single
+      source of truth for the gates `v0.6`, `v0.8`, `v0.9`, `v0.99`, `v1.0`)
+      rather than a hard-coded version list:
       ```yaml
-      case "${VERSION}" in
-        v0.6.0|v0.8.0|v0.9.0|v0.99.0|v0.99.1|v1.0.0)
-          echo "OFFICIAL_RELEASE=true" >> "$GITHUB_ENV" ;;
-        *)
-          echo "OFFICIAL_RELEASE=false" >> "$GITHUB_ENV" ;;
-      esac
+      if ./scripts/release-info.sh is-milestone "${VERSION}"; then
+        echo "OFFICIAL_RELEASE=true" >> "$GITHUB_ENV"
+      else
+        echo "OFFICIAL_RELEASE=false" >> "$GITHUB_ENV"
+      fi
       ```
 - [ ] Export `VERSION` and `DATE` in the build step so the Makefile picks
       them up:
@@ -241,15 +246,15 @@ are the same either way — only the path changes.
 ## Step 6 — Verify the PDF
 
 ```bash
-make VERSION=v0.8.0 DATE=2026-06-12
+make VERSION=v0.8 DATE=2026-06-12
 ls build/
 ```
-You should see exactly one PDF named `<short>-v0.8.0-20260612.pdf`. Open it
+You should see exactly one PDF named `<short>-v0.8-20260612.pdf`. Open it
 and confirm:
 
-- [ ] **Filename** contains short name, `v0.8.0`, and `20260612`.
+- [ ] **Filename** contains short name, `v0.8`, and `20260612`.
 - [ ] **Page 1 (title page)** ends with the line:
-      `Version v0.8.0, 2026-06-12: Stabilized`.
+      `Version v0.8, 2026-06-12: Stabilized`.
 - [ ] **Page 2** is a preface titled `Document State` whose only content is
       a `Note:` paragraph with the phase notice.
 - [ ] **Page 3** is the Table of Contents (and includes `Document State`
@@ -316,7 +321,7 @@ rest of the library — notably `sectnums`, which the central section-numbering
 extension owns.
 
 - [ ] `name`, `title` — yours.
-- [ ] `version: v0.0.0` — placeholder; stamped at release (Step 12). Do not
+- [ ] `version: v0.0` — placeholder; stamped at release (Step 12). Do not
       hand-edit thereafter.
 - [ ] `nav:` → `- modules/ROOT/nav.adoc`.
 - [ ] `asciidoc.attributes.asamBibliography: 'ROOT:resources/<spec>.bib'` if you
@@ -409,8 +414,9 @@ file.
 - [ ] Sync the upstream `build-pdf.yml` `stamp-site-version` job. On every real
       release (it skips PR previews and drafts) it stamps `antora.yml` and opens
       a **review PR** against `main` titled
-      `Stamp Antora site version vX.Y.Z to match released PDF`. It is monotonic —
-      it will not stamp `main` backwards when an older tag is rebuilt.
+      `Stamp Antora site version vX.Y to match released PDF`. It is monotonic —
+      it will not stamp `main` backwards when an older tag is rebuilt (it
+      compares by decimal value via `release-info.sh`, not `sort -V`).
 - [ ] **Merging that PR is part of cutting a release** (Step 14). Until it
       merges, the site version lags the released PDF. It deliberately opens a PR
       rather than pushing to `main` directly so it works whatever branch
@@ -418,8 +424,8 @@ file.
       and the site silently stale.
 - [ ] Verify:
       ```bash
-      make stamp-antora VERSION=v0.8.0 DATE=2026-06-12
-      git diff antora.yml     # version: v0.8.0, page-phase-display: 'Stabilized'
+      make stamp-antora VERSION=v0.8 DATE=2026-06-12
+      git diff antora.yml     # version: v0.8, page-phase-display: 'Stabilized'
       ```
       Then restamp to your repo's real state before committing.
 
@@ -444,21 +450,21 @@ When you're ready to advance to the next milestone:
 
 - [ ] Open the `Create Specification Document` workflow → `Run workflow`.
 - [ ] Pick the target milestone from `target_phase` (or leave on `auto-next`
-      for an intermediate patch tag).
+      for an intermediate revision tag).
 - [ ] Confirm the resulting release has a single PDF whose name matches the
       ARC convention.
 - [ ] **Review and merge the site version stamp PR** the release opened
-      (`Stamp Antora site version vX.Y.Z to match released PDF`). The site
+      (`Stamp Antora site version vX.Y to match released PDF`). The site
       version does not track the PDF until you do. The values are generated from
       `release-info.sh`, so this wants a merge, not an edit.
 - [ ] After it merges, confirm the site renders at `/<component>/<version>/` with
-      a cover reading `Version vX.Y.Z, YYYY-MM-DD: <Display>` — identical to the
+      a cover reading `Version vX.Y, YYYY-MM-DD: <Display>` — identical to the
       PDF title page.
 - [ ] **Releasing locally or offline?** The CI stamp doesn't run, so do it by
       hand or the site version silently lags the PDF:
       ```bash
-      make stamp-antora VERSION=vX.Y.Z
-      git add antora.yml && git commit -m "Stamp site version vX.Y.Z"
+      make stamp-antora VERSION=vX.Y
+      git add antora.yml && git commit -m "Stamp site version vX.Y"
       ```
 - [ ] If you changed `nav.adoc` this cycle, re-check the central
       `numbering_rules` entry (Step 11) — including its `branches:`/`tags:`.
@@ -475,8 +481,10 @@ When you're ready to advance to the next milestone:
 
 ### PDF
 
-- **Existing pre-`v0.6.0` tags:** the script labels them `draft-and-development`,
-  which is fine. No action needed.
+- **Existing pre-`v0.6` tags:** the script labels them `draft-and-development`,
+  which is fine. No action needed. **Old 3-digit tags** (`v0.8.0`) are not valid
+  in the 2-digit scheme and are ignored by `release-info.sh latest`; do not
+  delete them, just cut new 2-digit tags going forward.
 - **Repos that don't use this template's Makefile:** you still need to emit a
   PDF named per §3.2 of `ARC_SUBMISSION.md` and a title page per §3.3.
   Adopting the template Makefile is the easiest way; otherwise replicate the

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ all: build
 
 # Stamp antora.yml with the current VERSION/DATE so the Antora HTML site version
 # stays in EXACT lockstep with the ARC PDF (both derive from release-info.sh /
-# the git tag). Run at release time -- e.g. `make stamp-antora VERSION=v0.8.0`.
+# the git tag). Run at release time -- e.g. `make stamp-antora VERSION=v0.8`.
 # No Docker needed; edits antora.yml in place and must be committed.
 stamp-antora:
 	./scripts/stamp-antora-version.sh "$(VERSION)" "$(DATE)"

--- a/README.adoc
+++ b/README.adoc
@@ -6,7 +6,7 @@ NOTE: If you are viewing this in a specification repository, kindly update the t
 
 [IMPORTANT]
 ====
-**ARC submissions:** Specifications submitted to the Architecture Review Committee (ARC) must follow the conventions in link:ARC_SUBMISSION.md[ARC_SUBMISSION.md] — versioned GitHub tag, PDF named `<short>-v<X.Y.Z>-<YYYYMMDD>.pdf`, and a title page that matches. The Makefile and CI workflows in this template produce ARC-compliant artifacts on every build by default.
+**ARC submissions:** Specifications submitted to the Architecture Review Committee (ARC) must follow the conventions in link:ARC_SUBMISSION.md[ARC_SUBMISSION.md] — versioned GitHub tag, PDF named `<short>-v<MAJOR>.<MINOR>-<YYYYMMDD>.pdf`, and a title page that matches. The Makefile and CI workflows in this template produce ARC-compliant artifacts on every build by default.
 
 **Migrating an existing repo?** See link:MIGRATION.md[MIGRATION.md] for the step-by-step checklist to bring a downstream fork in line with the current toolchain — both the ARC submission PDF and the Antora site, which share one source tree. See link:ANTORA.md[ANTORA.md] for how that dual build works and why.
 ====
@@ -122,7 +122,7 @@ The version bot runs on pushes to `main` only when files under `src/**` change (
 === End-to-end flow
 
 1. A commit that changes `src/**` is pushed to `main`.
-2. `.github/workflows/version-bot.yml` finds the latest `v*` tag and creates the next patch tag (`vX.Y.Z`) for that commit.
+2. `.github/workflows/version-bot.yml` finds the latest `v*` tag and creates the next revision tag (`vMAJOR.MINOR`) for that commit.
 3. The new tag triggers `.github/workflows/build-pdf.yml`.
 4. The build uses the tag as `:revnumber:` and sets `:revdate:` to the build date.
 5. `scripts/release-info.sh` derives phase (`:phase:`), display state (`:phase_display:`), warning text (`:phase_notice:`), and `:revremark:` from the version milestone.
@@ -130,27 +130,27 @@ The version bot runs on pushes to `main` only when files under `src/**` change (
 
 Version increment policy:
 
-* Normal step: increment patch (`vA.B.C` -> `vA.B.(C+1)`).
-* Pre-1.0 rollover: for `v0.B.C` where `B < 99`, `v0.B.99` rolls to `v0.(B+1).0`.
-* `v0.99.x` continues patch-only until maintainers intentionally ratify with `v1.0.0`.
+* Versions are two-digit `vMAJOR.MINOR` as a fixed-point decimal (`v0.6` = 0.60, `v1.0` = 1.00). Ordering is decimal, not semver: `v0.8` (0.80) is greater than `v0.61`.
+* Normal step: advance the revision by `0.01` (`v0.61` -> `v0.62`).
+* Milestone gates (`v0.6`, `v0.8`, `v0.9`, `v0.99`, `v1.0`) are cut manually; the bot never auto-advances onto a gate. When a band is exhausted (for example `v0.79`), a maintainer cuts the next milestone.
 
 === Milestone boundaries
 
-* `v0.6.x`: `Developed`
-* `v0.8.x`: `Stable`
-* `v0.9.x`: `Frozen`
-* `v0.99.x`: `Ratification-Ready`
-* `v1.0.0`: `Ratified`
+* `v0.6`: `Developed` (revisions `v0.61`–`v0.79`)
+* `v0.8`: `Stable` (revisions `v0.81`–`v0.89`)
+* `v0.9`: `Frozen` (revisions `v0.91`–`v0.98`)
+* `v0.99`: `Ratification-Ready`
+* `v1.0`: `Ratified`
 
 === Official vs prerelease policy
 
 Only these exact versions are published as official releases (`prerelease=false`):
 
-* `v0.6.0`
-* `v0.8.0`
-* `v0.9.0`
-* `v0.99.0`
-* `v1.0.0`
+* `v0.6`
+* `v0.8`
+* `v0.9`
+* `v0.99`
+* `v1.0`
 
 All other versions are published as prereleases (`prerelease=true`).
 
@@ -163,16 +163,16 @@ When a new tag crosses into a different phase than the previous tag, the bot ope
 `workflow_dispatch` for `.github/workflows/build-pdf.yml` supports:
 
 * `release_version` to force an explicit version.
-* `target_phase` to force a milestone floor (`Developed` -> `v0.6.0`, `Stable` -> `v0.8.0`, and so on).
-* With `target_phase=auto-next` (default), manual runs use the latest existing tag if that tag is between milestone floors; otherwise they compute the next patch.
+* `target_phase` to force a milestone floor (`Developed` -> `v0.6`, `Stable` -> `v0.8`, and so on).
+* With `target_phase=auto-next` (default), manual runs use the latest existing tag if that tag is between milestone floors; otherwise they compute the next revision.
 
 === Manual version jumps
 
 `workflow_dispatch` for `.github/workflows/version-bot.yml` supports forced jumps:
 
-* Set `target_phase=Frozen` to force the milestone floor (`v0.9.0`).
-* Set `target_phase=Stable` to force `v0.8.0`, `Ratification-Ready` to force `v0.99.0`, and so on.
-* Set `release_version` (for example `v0.9.0`) to force an explicit version; this takes precedence over `target_phase`.
+* Set `target_phase=Frozen` to force the milestone floor (`v0.9`).
+* Set `target_phase=Stable` to force `v0.8`, `Ratification-Ready` to force `v0.99`, and so on.
+* Set `release_version` (for example `v0.9`) to force an explicit version; this takes precedence over `target_phase`.
 * Manual jumps must run on `main`.
 * By default, backward jumps are blocked; set `allow_non_monotonic=true` only when intentionally overriding this safety check.
 

--- a/SPEC_STATE.md
+++ b/SPEC_STATE.md
@@ -2,16 +2,16 @@
 
 Current milestone: Draft and Development
 Current state: Draft and Development
-Current version: v0.0.0
+Current version: v0.0
 Last updated: 2026-02-19
 
 ## Milestone Targets
 
-- v0.6.x Developed
-- v0.8.x Stable
-- v0.9.x Frozen
-- v0.99.x Ratification-Ready
-- v1.0.0 Ratified
+- v0.6 Developed
+- v0.8 Stable
+- v0.9 Frozen
+- v0.99 Ratification-Ready
+- v1.0 Ratified
 
 ## State Definitions
 

--- a/antora.yml
+++ b/antora.yml
@@ -18,11 +18,11 @@
 name: spec-sample
 title: RISC-V Example Specification (Zexmpl)
 # The site version is kept in EXACT lockstep with the ARC submission PDF: it is
-# the vX.Y.Z release tag, per the ARC Author Guide. Do not hand-edit -- it is
+# the vX.Y release tag, per the ARC Author Guide. Do not hand-edit -- it is
 # stamped from scripts/release-info.sh (the same source the PDF build uses) by
 # scripts/stamp-antora-version.sh / `make stamp-antora`, so the site path
 # (/spec-sample/<version>/) and the released PDF filename always match.
-version: v0.0.0
+version: v0.0
 
 nav:
   - modules/ROOT/nav.adoc
@@ -42,7 +42,7 @@ asciidoc:
     # shared-rendering override. Stamped by scripts/stamp-antora-version.sh; the
     # `version:` key above is the authoritative version and page-revnumber mirrors
     # it for display. Do not hand-edit.
-    page-revnumber: v0.0.0
+    page-revnumber: v0.0
     page-revdate: 2026-07-14
     page-phase: draft-and-development
     page-phase-display: 'Draft and Development'

--- a/scripts/release-info.sh
+++ b/scripts/release-info.sh
@@ -1,20 +1,52 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-DEFAULT_VERSION="v0.0.0"
+# Two-digit (fixed-point decimal) release metadata for the RISC-V spec lifecycle.
+#
+# Versions are `vMAJOR.FRAC` where the value is a decimal to hundredths:
+# v0.0 = 0.00, v0.6 = 0.60, v0.61 = 0.61, v0.99 = 0.99, v1.0 = 1.00. Ordering is
+# therefore DECIMAL, not per-component semver: v0.8 (0.80) > v0.61 (0.61). Do NOT
+# compare these with `sort -V` or `git ... --sort=version:refname` -- both order
+# the fractional part component-wise and get v0.8 < v0.61 wrong. Use the `compare`
+# / `max` / `latest` subcommands here, which compare by centi-value.
+#
+# Milestones (manual gates, one release each): v0.6 development-complete,
+# v0.8 stabilized, v0.9 frozen, v0.99 ratification-ready, v1.0 ratified. v0.0 is
+# the inception version. Between milestones, merges to main auto-advance by 0.01
+# (v0.61, v0.62, ... v0.79) up to -- but never onto -- the next manual milestone.
+
+DEFAULT_VERSION="v0.0"
 DEFAULT_PHASE="draft-and-development"
 SPEC_STATE_URL="http://riscv.org/spec-state"
-MAX_PATCH_BEFORE_MINOR_BUMP="${MAX_PATCH_BEFORE_MINOR_BUMP:-99}"
+
+# `next` exits with this code when the auto-increment band is exhausted (the next
+# 0.01 step would land on a manual milestone gate). Callers trap it to skip
+# tagging rather than hard-fail.
+NEXT_AT_MILESTONE_RC=10
 
 usage() {
   cat <<'USAGE'
-Usage: scripts/release-info.sh [version|normalize|next|phase|phase-floor-version|display|milestone|notice|revremark|all] [value]
+Usage: scripts/release-info.sh <command> [value ...]
 
-Outputs release metadata derived from VERSION/RELEASE_VERSION, git tags, or defaults.
+Commands:
+  version                 Resolve version from VERSION/RELEASE_VERSION/git tags.
+  latest                  Highest valid v* git tag (decimal order), or default.
+  normalize <v>           Canonicalize a version string (v0.60 -> v0.6).
+  next [v]                Next auto version (+0.01); errors at a milestone gate.
+  compare <a> <b>         Print -1 / 0 / 1 for a<b / a==b / a>b (decimal order).
+  max <a> <b>             Print the greater of two versions.
+  is-milestone <v>        Exit 0 if v is a manual milestone gate.
+  phase [v]               Lifecycle phase (state) for a version.
+  phase-floor-version <p> Version at the gate of phase p.
+  display [v]             Title-case display label for a version's phase.
+  milestone [v]           "<gate> <phase>" milestone label.
+  notice [v]              Change-control notice text for a version's phase.
+  revremark [v]           Revision remark (display label) for a version.
+  all                     Emit all of the above as KEY=VALUE lines.
 USAGE
 }
 
-normalize_version() {
+normalize_prefix() {
   local v="$1"
   v="${v##*/}"
   if [[ "$v" != v* ]]; then
@@ -34,46 +66,129 @@ base_version() {
 version_valid() {
   local v
   v="$(base_version "$1")"
-  [[ "$v" =~ ^[0-9]+(\.[0-9]+){1,2}$ ]]
+  [[ "$v" =~ ^[0-9]+\.[0-9]+$ ]]
 }
 
-parse_version() {
-  local v major minor patch
+# Centi-value: MAJOR*100 + fractional-hundredths. The fractional part is padded
+# to two digits so v0.6 == v0.60 == 60. v1.0 -> 100, v0.0 -> 0.
+centi_of() {
+  local v major frac
   v="$(base_version "$1")"
-  IFS='.' read -r major minor patch <<<"$v"
-  patch="${patch:-0}"
-  echo "$major" "$minor" "$patch"
+  IFS='.' read -r major frac <<<"$v"
+  frac="${frac:-0}"
+  frac="${frac}00"
+  frac="${frac:0:2}"
+  echo $(( 10#$major * 100 + 10#$frac ))
+}
+
+is_milestone_centi() {
+  case "$1" in
+    60|80|90|99|100) return 0 ;;
+    *)               return 1 ;;
+  esac
+}
+
+# Canonical short (policy) form for a milestone centi-value.
+milestone_string_for_centi() {
+  case "$1" in
+    0)   echo "v0.0"  ;;
+    60)  echo "v0.6"  ;;
+    80)  echo "v0.8"  ;;
+    90)  echo "v0.9"  ;;
+    99)  echo "v0.99" ;;
+    100) echo "v1.0"  ;;
+    *)   return 1     ;;
+  esac
+}
+
+# Format an arbitrary centi-value as a version string. Milestone values use the
+# short policy form (60 -> v0.6); non-milestone auto values use the two-digit
+# fractional form (70 -> v0.70, 5 -> v0.05).
+format_centi() {
+  local c="$1" major frac
+  major=$(( c / 100 ))
+  frac=$(( c % 100 ))
+  if milestone_string_for_centi "$c" >/dev/null 2>&1; then
+    milestone_string_for_centi "$c"
+  elif (( frac == 0 )); then
+    printf 'v%d.0\n' "$major"
+  else
+    printf 'v%d.%02d\n' "$major" "$frac"
+  fi
+}
+
+canonical_version() {
+  format_centi "$(centi_of "$1")"
 }
 
 version_ge() {
-  local a1 b1 c1 a2 b2 c2
-  read -r a1 b1 c1 <<<"$(parse_version "$1")"
-  read -r a2 b2 c2 <<<"$(parse_version "$2")"
-  if (( a1 > a2 )); then
-    return 0
+  local a b
+  a="$(centi_of "$1")"
+  b="$(centi_of "$2")"
+  (( a >= b ))
+}
+
+compare_versions() {
+  local a b
+  a="$(centi_of "$1")"
+  b="$(centi_of "$2")"
+  if (( a < b )); then
+    echo -1
+  elif (( a > b )); then
+    echo 1
+  else
+    echo 0
   fi
-  if (( a1 == a2 && b1 > b2 )); then
-    return 0
+}
+
+max_version() {
+  if version_ge "$1" "$2"; then
+    canonical_version "$1"
+  else
+    canonical_version "$2"
   fi
-  if (( a1 == a2 && b1 == b2 && c1 >= c2 )); then
-    return 0
-  fi
-  return 1
 }
 
 next_version() {
-  local major minor patch
-  read -r major minor patch <<<"$(parse_version "$1")"
+  local c n
+  c="$(centi_of "$1")"
 
-  # Progress pre-1.0 development by rolling patch to the next minor at .99.
-  if (( major == 0 && minor < 99 && patch >= MAX_PATCH_BEFORE_MINOR_BUMP )); then
-    minor=$((minor + 1))
-    patch=0
-  else
-    patch=$((patch + 1))
+  if (( c >= 100 )); then
+    echo "release-info: $1 is at or past v1.0 (ratified); no automatic successor." >&2
+    exit 2
   fi
 
-  printf 'v%s.%s.%s\n' "$major" "$minor" "$patch"
+  n=$(( c + 1 ))
+  if is_milestone_centi "$n"; then
+    local ms
+    ms="$(milestone_string_for_centi "$n")"
+    echo "release-info: next step $ms is a manual milestone gate; cut it via workflow_dispatch (target_phase or release_version)." >&2
+    exit "$NEXT_AT_MILESTONE_RC"
+  fi
+
+  format_centi "$n"
+}
+
+# Highest valid v* tag by decimal (centi) order -- git's version sort cannot be
+# trusted for this scheme (it would rank v0.8 below v0.61).
+latest_tag() {
+  local best="" bestc=-1 t tc
+  if command -v git >/dev/null 2>&1; then
+    while IFS= read -r t; do
+      [[ -n "$t" ]] || continue
+      version_valid "$t" || continue
+      tc="$(centi_of "$t")"
+      if (( tc > bestc )); then
+        bestc="$tc"
+        best="$t"
+      fi
+    done < <(git tag --list 'v*' 2>/dev/null || true)
+  fi
+  if [[ -n "$best" ]]; then
+    canonical_version "$best"
+  else
+    echo "$DEFAULT_VERSION"
+  fi
 }
 
 get_version() {
@@ -94,55 +209,45 @@ get_version() {
     fi
   fi
 
-  if [[ -z "$v" ]] && command -v git >/dev/null 2>&1; then
-    v="$(git tag --list 'v*' --sort=-version:refname | head -n1 || true)"
-  fi
-
   if [[ -n "$v" ]] && version_valid "$v"; then
-    normalize_version "$v"
+    canonical_version "$v"
     return 0
   fi
 
-  echo "$DEFAULT_VERSION"
+  latest_tag
 }
 
 phase_display_for_phase() {
-  # Title-case display label rendered on the PDF title page and in the body
-  # NOTE admonition. The canonical (lowercase, hyphenated) ID stays usable for
-  # filenames, scripts, and machine-readable consumers; this is the human form.
   case "$1" in
     "draft-and-development") echo "Draft and Development" ;;
     "development-complete")  echo "Development Complete"  ;;
     "stabilized")            echo "Stabilized"            ;;
     "frozen")                echo "Frozen"                ;;
     "ratification-ready")    echo "Ratification-Ready"    ;;
-    "publication")           echo "Publication"           ;;
     "ratified")              echo "Ratified"              ;;
     *)                       echo "Draft"                 ;;
   esac
 }
 
 phase_for_version() {
-  local v="$1"
+  local v="$1" c
 
   if ! version_valid "$v"; then
     echo "$DEFAULT_PHASE"
     return 0
   fi
 
-  # Canonical RISC-V P&P milestone IDs. The version number encodes the
-  # milestone gate; see ARC_SUBMISSION.md.
-  if version_ge "$v" "v1.0.0"; then
+  c="$(centi_of "$v")"
+
+  if (( c >= 100 )); then
     echo "ratified"
-  elif version_ge "$v" "v0.99.1"; then
-    echo "publication"
-  elif version_ge "$v" "v0.99.0"; then
+  elif (( c >= 99 )); then
     echo "ratification-ready"
-  elif version_ge "$v" "v0.9.0"; then
+  elif (( c >= 90 )); then
     echo "frozen"
-  elif version_ge "$v" "v0.8.0"; then
+  elif (( c >= 80 )); then
     echo "stabilized"
-  elif version_ge "$v" "v0.6.0"; then
+  elif (( c >= 60 )); then
     echo "development-complete"
   else
     echo "draft-and-development"
@@ -151,53 +256,23 @@ phase_for_version() {
 
 milestone_for_phase() {
   case "$1" in
-    "development-complete")
-      echo "v0.6.x development-complete"
-      ;;
-    "stabilized")
-      echo "v0.8.x stabilized"
-      ;;
-    "frozen")
-      echo "v0.9.x frozen"
-      ;;
-    "ratification-ready")
-      echo "v0.99.0 ratification-ready"
-      ;;
-    "publication")
-      echo "v0.99.x publication"
-      ;;
-    "ratified")
-      echo "v1.0.x ratified"
-      ;;
-    *)
-      echo "draft-and-development"
-      ;;
+    "development-complete") echo "v0.6 development-complete" ;;
+    "stabilized")          echo "v0.8 stabilized"           ;;
+    "frozen")              echo "v0.9 frozen"               ;;
+    "ratification-ready")  echo "v0.99 ratification-ready"  ;;
+    "ratified")            echo "v1.0 ratified"             ;;
+    *)                     echo "draft-and-development"     ;;
   esac
 }
 
 phase_floor_version() {
   case "$1" in
-    "draft-and-development")
-      echo "v0.0.1"
-      ;;
-    "development-complete")
-      echo "v0.6.0"
-      ;;
-    "stabilized")
-      echo "v0.8.0"
-      ;;
-    "frozen")
-      echo "v0.9.0"
-      ;;
-    "ratification-ready")
-      echo "v0.99.0"
-      ;;
-    "publication")
-      echo "v0.99.1"
-      ;;
-    "ratified")
-      echo "v1.0.0"
-      ;;
+    "draft-and-development") echo "v0.0"  ;;
+    "development-complete")  echo "v0.6"  ;;
+    "stabilized")            echo "v0.8"  ;;
+    "frozen")                echo "v0.9"  ;;
+    "ratification-ready")    echo "v0.99" ;;
+    "ratified")              echo "v1.0"  ;;
     *)
       echo "Unknown phase '$1'" >&2
       return 2
@@ -207,7 +282,10 @@ phase_floor_version() {
 
 notice_for_phase() {
   case "$1" in
-    "draft-and-development"|"development-complete")
+    "draft-and-development")
+      echo "Assume everything is subject to change. At this stage, ideas, structures, and content are still evolving. Feedback and iteration are encouraged as nothing is final, and adjustments may be frequent."
+      ;;
+    "development-complete")
       echo "Assume everything is subject to change. At this stage, ideas, structures, and content are still evolving. Feedback and iteration are encouraged as nothing is final, and adjustments may be frequent."
       ;;
     "stabilized")
@@ -219,9 +297,6 @@ notice_for_phase() {
     "ratification-ready")
       echo "The specification is preparing for ratification. Only critical, ratification-blocking issues should be considered for change."
       ;;
-    "publication")
-      echo "The specification has cleared ratification-ready and is in the publication phase pending final ratification. Only publication-phase corrections are permitted."
-      ;;
     "ratified")
       echo "No changes are allowed. Any necessary or desired modifications must be addressed through a follow-on extension. Ratified extensions are never revised."
       ;;
@@ -232,12 +307,6 @@ notice_for_phase() {
 }
 
 revremark_for_phase() {
-  # revremark is rendered immediately under "Version <revnumber>, <revdate>" on
-  # the asciidoctor-pdf title page. Emit only the title-case milestone label so
-  # the title page reads:
-  #   Version v1.0.0, 2026-05-24
-  #          Ratified
-  # The longer policy text moves into the body NOTE admonition (notice_for_phase).
   phase_display_for_phase "$1"
 }
 
@@ -259,6 +328,9 @@ case "$command" in
   version)
     get_version
     ;;
+  latest)
+    latest_tag
+    ;;
   normalize)
     if [[ -z "$value" ]]; then
       echo "normalize requires a version value" >&2
@@ -268,13 +340,45 @@ case "$command" in
       echo "invalid version: $value" >&2
       exit 2
     fi
-    normalize_version "$value"
+    canonical_version "$value"
     ;;
   next)
     if [[ -z "$value" ]]; then
       value="$(get_version)"
     fi
+    if ! version_valid "$value"; then
+      echo "invalid version: $value" >&2
+      exit 2
+    fi
     next_version "$value"
+    ;;
+  compare)
+    if [[ -z "$value" || -z "${3:-}" ]]; then
+      echo "compare requires two version values" >&2
+      exit 2
+    fi
+    if ! version_valid "$value" || ! version_valid "$3"; then
+      echo "invalid version(s): $value $3" >&2
+      exit 2
+    fi
+    compare_versions "$value" "$3"
+    ;;
+  max)
+    if [[ -z "$value" || -z "${3:-}" ]]; then
+      echo "max requires two version values" >&2
+      exit 2
+    fi
+    if ! version_valid "$value" || ! version_valid "$3"; then
+      echo "invalid version(s): $value $3" >&2
+      exit 2
+    fi
+    max_version "$value" "$3"
+    ;;
+  is-milestone)
+    if [[ -z "$value" ]] || ! version_valid "$value"; then
+      exit 1
+    fi
+    is_milestone_centi "$(centi_of "$value")"
     ;;
   phase)
     if [[ -z "$value" ]]; then
@@ -309,12 +413,15 @@ case "$command" in
   all|"")
     version="$(get_version)"
     phase="$(phase_for_version "$version")"
-    display="$phase"
+    display="$(phase_display_for_phase "$phase")"
     milestone="$(milestone_for_phase "$phase")"
     notice="$(notice_for_phase "$phase")"
     revremark="$(revremark_for_phase "$phase")"
     printf 'VERSION=%s\nPHASE=%s\nPHASE_DISPLAY=%s\nMILESTONE=%s\nPHASE_NOTICE=%s\nREVMARK=%s\n' \
       "$version" "$phase" "$display" "$milestone" "$notice" "$revremark"
+    ;;
+  -h|--help|help)
+    usage
     ;;
   *)
     usage

--- a/scripts/stamp-antora-version.sh
+++ b/scripts/stamp-antora-version.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Stamp the Antora component descriptor (antora.yml) with the current release
 # version and phase so the HTML site version stays in EXACT lockstep with the
-# ARC submission PDF, per the ARC Author Guide (version = the vX.Y.Z tag; the
+# ARC submission PDF, per the ARC Author Guide (version = the vX.Y tag; the
 # title-page revision line is "Version <ver>, <date>: <Display>").
 #
 # The PDF derives its version dynamically at build time from the git tag via
@@ -10,7 +10,7 @@
 # analogue of scripts/update-spec-state.sh (which stamps SPEC_STATE.md).
 #
 # Usage: scripts/stamp-antora-version.sh [version] [date]
-#   version  vX.Y.Z (default: scripts/release-info.sh version -> latest tag)
+#   version  vX.Y (default: scripts/release-info.sh version -> latest tag)
 #   date     YYYY-MM-DD (default: today)
 #
 # Idempotent: it replaces the values of existing keys in antora.yml in place and
@@ -24,7 +24,7 @@ antora_yml="$repo_root/antora.yml"
 version="${1:-$("$here/release-info.sh" version)}"
 date="${2:-$(date +%Y-%m-%d)}"
 
-# Normalise and validate the version (vX.Y.Z) through the shared helper.
+# Normalise and validate the version (vX.Y) through the shared helper.
 version="$("$here/release-info.sh" normalize "$version")"
 
 phase="$("$here/release-info.sh" phase "$version")"

--- a/scripts/update-spec-state.sh
+++ b/scripts/update-spec-state.sh
@@ -22,11 +22,11 @@ Last updated: ${updated_on}
 
 ## Milestone Targets
 
-- v0.6.x Developed
-- v0.8.x Stable
-- v0.9.x Frozen
-- v0.99.x Ratification-Ready
-- v1.0.0 Ratified
+- v0.6 Developed
+- v0.8 Stable
+- v0.9 Frozen
+- v0.99 Ratification-Ready
+- v1.0 Ratified
 
 ## State Definitions
 

--- a/src/spec-sample.adoc
+++ b/src/spec-sample.adoc
@@ -1,7 +1,7 @@
 = RISC-V Example Specification Document (Zexmpl)
 Authors: Author 1, Author 2
 include::../docs-resources/global-config.adoc[]
-ifndef::revnumber[:revnumber: v0.0.0]
+ifndef::revnumber[:revnumber: v0.0]
 ifndef::revdate[:revdate: 1/2023]
 ifndef::phase[:phase: draft-and-development]
 ifndef::phase_display[:phase_display: {phase}]

--- a/tests/release-info-test.sh
+++ b/tests/release-info-test.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+#
+# Tests for scripts/release-info.sh -- the 2-digit (fixed-point decimal) release
+# metadata helper. These lock the subtle bits: DECIMAL ordering (v0.8 > v0.61,
+# which sort -V gets wrong), the +0.01 auto-increment, the milestone guard that
+# refuses to auto-mint a manual gate, phase detection, and normalization.
+#
+# Run: tests/release-info-test.sh   (exit 0 = all passed)
+set -uo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RI="$here/../scripts/release-info.sh"
+
+pass=0
+fail=0
+
+# ok <description> <expected> <actual>
+ok() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    pass=$(( pass + 1 ))
+  else
+    fail=$(( fail + 1 ))
+    printf 'FAIL: %s\n  expected: %q\n  actual:   %q\n' "$desc" "$expected" "$actual"
+  fi
+}
+
+# rc <description> <expected-rc> <command...>
+rc() {
+  local desc="$1" expected="$2"; shift 2
+  "$@" >/dev/null 2>&1
+  local actual=$?
+  if [[ "$actual" == "$expected" ]]; then
+    pass=$(( pass + 1 ))
+  else
+    fail=$(( fail + 1 ))
+    printf 'FAIL: %s\n  expected rc: %s\n  actual rc:   %s\n' "$desc" "$expected" "$actual"
+  fi
+}
+
+# --- decimal ordering (the sort -V / git version-sort trap) -----------------
+ok "compare v0.8 > v0.61"        1  "$("$RI" compare v0.8 v0.61)"
+ok "compare v0.61 < v0.8"       -1  "$("$RI" compare v0.61 v0.8)"
+ok "compare v0.6 == v0.60"       0  "$("$RI" compare v0.6 v0.60)"
+ok "compare v0.99 > v0.9"        1  "$("$RI" compare v0.99 v0.9)"
+ok "compare v1.0 > v0.99"        1  "$("$RI" compare v1.0 v0.99)"
+ok "compare v0.9 > v0.89"        1  "$("$RI" compare v0.9 v0.89)"
+ok "max v0.8 v0.61 = v0.8"    v0.8  "$("$RI" max v0.8 v0.61)"
+ok "max v0.70 v0.9 = v0.9"    v0.9  "$("$RI" max v0.70 v0.9)"
+
+# --- normalization / canonical form -----------------------------------------
+ok "normalize v0.60 -> v0.6"  v0.6   "$("$RI" normalize v0.60)"
+ok "normalize v0.6 -> v0.6"   v0.6   "$("$RI" normalize v0.6)"
+ok "normalize v0.7 -> v0.70"  v0.70  "$("$RI" normalize v0.7)"
+ok "normalize 0.99 -> v0.99"  v0.99  "$("$RI" normalize 0.99)"
+ok "normalize v1.0 -> v1.0"   v1.0   "$("$RI" normalize v1.0)"
+ok "normalize v0.0 -> v0.0"   v0.0   "$("$RI" normalize v0.0)"
+
+# --- auto-increment (+0.01) --------------------------------------------------
+ok "next v0.6 -> v0.61"   v0.61  "$("$RI" next v0.6)"
+ok "next v0.61 -> v0.62"  v0.62  "$("$RI" next v0.61)"
+ok "next v0.69 -> v0.70"  v0.70  "$("$RI" next v0.69)"
+ok "next v0.05 -> v0.06"  v0.06  "$("$RI" next v0.05)"
+ok "next v0.0 -> v0.01"   v0.01  "$("$RI" next v0.0)"
+ok "next v0.9 -> v0.91"   v0.91  "$("$RI" next v0.9)"
+
+# --- milestone guard: auto-increment must never mint a manual gate ----------
+rc "next v0.59 refuses v0.6"   10  "$RI" next v0.59
+rc "next v0.79 refuses v0.8"   10  "$RI" next v0.79
+rc "next v0.89 refuses v0.9"   10  "$RI" next v0.89
+rc "next v0.98 refuses v0.99"  10  "$RI" next v0.98
+rc "next v0.99 refuses v1.0"   10  "$RI" next v0.99
+rc "next v1.0 has no successor"  2  "$RI" next v1.0
+
+# --- is-milestone ------------------------------------------------------------
+rc "v0.6 is a milestone"    0  "$RI" is-milestone v0.6
+rc "v0.8 is a milestone"    0  "$RI" is-milestone v0.8
+rc "v0.9 is a milestone"    0  "$RI" is-milestone v0.9
+rc "v0.99 is a milestone"   0  "$RI" is-milestone v0.99
+rc "v1.0 is a milestone"    0  "$RI" is-milestone v1.0
+rc "v0.61 not a milestone"  1  "$RI" is-milestone v0.61
+rc "v0.7 not a milestone"   1  "$RI" is-milestone v0.7
+
+# --- phase detection (state achieved) ---------------------------------------
+ok "phase v0.0"   draft-and-development  "$("$RI" phase v0.0)"
+ok "phase v0.3"   draft-and-development  "$("$RI" phase v0.3)"
+ok "phase v0.59"  draft-and-development  "$("$RI" phase v0.59)"
+ok "phase v0.6"   development-complete   "$("$RI" phase v0.6)"
+ok "phase v0.72"  development-complete   "$("$RI" phase v0.72)"
+ok "phase v0.8"   stabilized             "$("$RI" phase v0.8)"
+ok "phase v0.85"  stabilized             "$("$RI" phase v0.85)"
+ok "phase v0.9"   frozen                 "$("$RI" phase v0.9)"
+ok "phase v0.98"  frozen                 "$("$RI" phase v0.98)"
+ok "phase v0.99"  ratification-ready     "$("$RI" phase v0.99)"
+ok "phase v1.0"   ratified               "$("$RI" phase v1.0)"
+
+# --- phase floors round-trip -------------------------------------------------
+ok "floor draft-and-development" v0.0   "$("$RI" phase-floor-version draft-and-development)"
+ok "floor development-complete"  v0.6   "$("$RI" phase-floor-version development-complete)"
+ok "floor stabilized"            v0.8   "$("$RI" phase-floor-version stabilized)"
+ok "floor frozen"                v0.9   "$("$RI" phase-floor-version frozen)"
+ok "floor ratification-ready"    v0.99  "$("$RI" phase-floor-version ratification-ready)"
+ok "floor ratified"              v1.0   "$("$RI" phase-floor-version ratified)"
+
+# --- display labels ----------------------------------------------------------
+ok "display v0.8"  Stabilized  "$("$RI" display v0.8)"
+ok "display v1.0"  Ratified    "$("$RI" display v1.0)"
+
+# --- publication milestone is gone ------------------------------------------
+rc "publication is not a valid phase floor"  2  "$RI" phase-floor-version publication
+
+# --- 3-digit input is rejected ----------------------------------------------
+rc "normalize rejects v0.6.0"  2  "$RI" normalize v0.6.0
+rc "normalize rejects v0.99.1" 2  "$RI" normalize v0.99.1
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[[ "$fail" -eq 0 ]]


### PR DESCRIPTION
Closes #115.

Switches the spec lifecycle from 3-digit semver (`v0.6.0`) to the RISC-V Development Process policy's **2-digit fixed-point decimal** scheme, where merges to `main` auto-advance the revision by `0.01` and milestone gates are cut **manually**.

## Policy model

| Band (activity)        | Auto tags (merges) | Manual milestone gate | State label           |
| ---------------------- | ------------------ | --------------------- | --------------------- |
| Planning → Development | `v0.01`…`v0.59`    | — (`v0.0` inception)  | Draft and Development |
| Stabilization          | `v0.61`…`v0.79`    | **`v0.6`**            | Development Complete  |
| Freezing               | `v0.81`…`v0.89`    | **`v0.8`**            | Stabilized            |
| Ratification-Ready     | `v0.91`…`v0.98`    | **`v0.9`**            | Frozen                |
| Publication            | *(none — no room)* | **`v0.99`**           | Ratification-Ready    |
| —                      | —                  | **`v1.0`**            | Ratified              |

## Why this was more than a string swap

1. **Decimal ordering** — `v0.8` (0.80) must sort greater than `v0.61`, but `sort -V` / git version-sort rank it lower. Every monotonic guard and the comparison logic now use centi-value comparison via `release-info.sh`.
2. **Increment axis** — changed from patch to hundredths (`+0.01`), with a guard so auto-increment never lands on a manual milestone (refuses at `v0.79` rather than minting `v0.8`).
3. **Removed the phantom `publication` / `v0.99.1` milestone** — Publication is a phase (`v0.99` → `v1.0`), not a distinct version.

## Changes

- **`scripts/release-info.sh`** — 2-digit regex, decimal compare, `next` + milestone guard, updated phase floors/thresholds, drop `publication`, new `latest`/`compare`/`max`/`is-milestone` subcommands.
- **Workflows** (`version-bot.yml`, `build-pdf.yml`) — replace `sort -V` guards with `compare`; `is-milestone` for OFFICIAL_RELEASE; graceful stop at milestone boundaries; drop `publication` from dropdowns.
- **Placeholders/state** (`antora.yml`, `src/spec-sample.adoc`, `SPEC_STATE.md`, `update-spec-state.sh`) → `v0.0` / 2-digit.
- **Docs** (`ARC_SUBMISSION.md`, `CONTRIBUTING.md`, `README.adoc`, `MIGRATION.md`, `ANTORA.md`) — rewritten to 2-digit and de-published. Realigns ARC doc with its own verbatim example `Zifoo-v0.8-20260520.pdf`.
- **`tests/release-info-test.sh`** (new, 55 assertions) — locks ordering, increment, milestone-guard, phase-detection, and normalization semantics.

## Verification

- 55/55 tests pass; `bash -n` clean; both workflow YAMLs parse.
- `make` dry-run emits the 2-digit ARC filename (`…-v0.8-20260612.pdf`, `revnumber=v0.8`).
- `make stamp-antora` produces valid 2-digit output for milestone and mid-band versions.

## Open decision for reviewers

Milestone tags render in short policy form (`v0.6`) rather than uniform two-digit (`v0.60`); `normalize` treats them as equivalent. Easy to switch to uniform form if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
