### PR TITLE
ci: fix duplicate Authorization header in create-pull-request jobs

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -217,6 +217,10 @@ jobs:
           ref: main
           fetch-depth: 0
           token: ${{ secrets.GHTOKEN || secrets.GITHUB_TOKEN }}
+          # Do not persist the token as a git extraheader. create-pull-request
+          # injects its own auth header; a persisted one here makes git send two
+          # Authorization headers -> GitHub 400 "Duplicate header: Authorization".
+          persist-credentials: false
 
       - name: Stamp antora.yml to match the released PDF version
         id: stamp

--- a/.github/workflows/version-bot.yml
+++ b/.github/workflows/version-bot.yml
@@ -161,6 +161,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # See build-pdf.yml: create-pull-request adds its own auth header, so a
+          # persisted token here yields a duplicate Authorization header (400).
+          persist-credentials: false
 
       - name: Update specification state
         run: |


### PR DESCRIPTION
## Problem

The `stamp-site-version` job (`build-pdf.yml`) and the `milestone-pr` job (`version-bot.yml`) fail when they try to open their automated PR:

```
remote: Duplicate header: "Authorization"
fatal: unable to access 'https://github.com/.../': The requested URL returned error: 400
The process '/usr/bin/git' failed with exit code 128
```

Each job checks out the repo with a token, then hands the same token to `peter-evans/create-pull-request`. `actions/checkout` persists the token as a git `http.<url>.extraheader` (`AUTHORIZATION: basic ***`), and the action injects its **own** auth header when it runs git (`git remote prune origin`). Two `Authorization` headers on one request → GitHub returns `400 Duplicate header`.

Observed live in a release build (the PDF built fine; only the follow-up site-version-stamp PR failed).

## Fix

Set `persist-credentials: false` on the two checkouts that feed a `create-pull-request` step, so only the action's own auth header is sent.

The `tag-version` checkout in `version-bot.yml` is intentionally left untouched — it runs `git push origin <tag>` directly and needs the persisted credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)