### PR TITLE
feat: update versioning for manual release tagging and interim commits (#120)

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -217,6 +217,10 @@ jobs:
           ref: main
           fetch-depth: 0
           token: ${{ secrets.GHTOKEN || secrets.GITHUB_TOKEN }}
+          # Do not persist the token as a git extraheader. create-pull-request
+          # injects its own auth header; a persisted one here makes git send two
+          # Authorization headers -> GitHub 400 "Duplicate header: Authorization".
+          persist-credentials: false
 
       - name: Stamp antora.yml to match the released PDF version
         id: stamp

--- a/.github/workflows/version-bot.yml
+++ b/.github/workflows/version-bot.yml
@@ -161,6 +161,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # See build-pdf.yml: create-pull-request adds its own auth header, so a
+          # persisted token here yields a duplicate Authorization header (400).
+          persist-credentials: false
 
       - name: Update specification state
         run: |

--- a/.github/workflows/version-bot.yml
+++ b/.github/workflows/version-bot.yml
@@ -2,11 +2,6 @@
 name: Version Bot
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - src/**
   workflow_dispatch:
     inputs:
       target_phase:

--- a/scripts/release-info.sh
+++ b/scripts/release-info.sh
@@ -118,7 +118,12 @@ format_centi() {
 }
 
 canonical_version() {
-  format_centi "$(centi_of "$1")"
+  local v="$1" suffix=""
+  if [[ "$v" == *-* ]]; then
+    suffix="-${v#*-}"
+    v="${v%%-*}"
+  fi
+  echo "$(format_centi "$(centi_of "$v")")${suffix}"
 }
 
 version_ge() {
@@ -211,6 +216,22 @@ get_version() {
 
   if [[ -n "$v" ]] && version_valid "$v"; then
     canonical_version "$v"
+    return 0
+  fi
+
+  if command -v git >/dev/null 2>&1 && git rev-parse --git-dir >/dev/null 2>&1; then
+    local exact_tag
+    exact_tag="$(git tag --points-at HEAD --list 'v*' 2>/dev/null | head -n1 || true)"
+    if [[ -n "$exact_tag" ]] && version_valid "$exact_tag"; then
+      canonical_version "$exact_tag"
+      return 0
+    fi
+
+    local latest short_sha build_date
+    latest="$(latest_tag)"
+    short_sha="$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")"
+    build_date="$(date +%Y%m%d)"
+    echo "${latest}-${short_sha}-${build_date}"
     return 0
   fi
 
@@ -375,7 +396,7 @@ case "$command" in
     max_version "$value" "$3"
     ;;
   is-milestone)
-    if [[ -z "$value" ]] || ! version_valid "$value"; then
+    if [[ -z "$value" ]] || ! version_valid "$value" || [[ "$value" == *-* ]]; then
       exit 1
     fi
     is_milestone_centi "$(centi_of "$value")"

--- a/tests/release-info-test.sh
+++ b/tests/release-info-test.sh
@@ -109,6 +109,11 @@ ok "display v1.0"  Ratified    "$("$RI" display v1.0)"
 # --- publication milestone is gone ------------------------------------------
 rc "publication is not a valid phase floor"  2  "$RI" phase-floor-version publication
 
+# --- interim build non-tagged versions ---------------------------------------
+ok "normalize v0.60-a1b2c3d-20260730" "v0.6-a1b2c3d-20260730" "$("$RI" normalize v0.60-a1b2c3d-20260730)"
+rc "v0.6-a1b2c3d-20260730 not a milestone" 1 "$RI" is-milestone v0.6-a1b2c3d-20260730
+ok "phase v0.6-a1b2c3d-20260730" development-complete "$("$RI" phase v0.6-a1b2c3d-20260730)"
+
 # --- 3-digit input is rejected ----------------------------------------------
 rc "normalize rejects v0.6.0"  2  "$RI" normalize v0.6.0
 rc "normalize rejects v0.99.1" 2  "$RI" normalize v0.99.1


### PR DESCRIPTION
Closes #120.

Summary:
- Removed Automated Versioning on Push: Changed version-bot.yml so version tags are only created when manually triggered via workflow_dispatch.
- Interim Non-Tagged Releases: Updated scripts/release-info.sh so builds between release tags output latest_tag-hash-build_date (e.g. v6.1-a1b2c3d-20260730).
- Unit Tests: Updated tests/release-info-test.sh to validate interim version formatting and phase resolution.