### PR TITLE
ci: let version bot's milestone PR trigger its own checks

### DIFF
--- a/.github/workflows/version-bot.yml
+++ b/.github/workflows/version-bot.yml
@@ -165,9 +165,26 @@ jobs:
           set -euo pipefail
           ./scripts/update-spec-state.sh "${{ needs.tag-version.outputs.next_version }}" "$(date +%Y-%m-%d)"
 
+      # A PR opened with GITHUB_TOKEN cannot trigger further workflow runs:
+      # GitHub parks them as `action_required` and a maintainer has to click
+      # "Approve and run" on every push to the branch. GHTOKEN gives the PR a
+      # real author so build-pdf/pre-commit/Vale/validate-content-source run on
+      # their own. Warn rather than fail -- without the secret the PR is still
+      # correct, its checks just need manual approval.
+      - name: Check for bot token
+        env:
+          GHTOKEN: ${{ secrets.GHTOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "$GHTOKEN" ]]; then
+            echo "::warning::GHTOKEN is not set. The milestone PR will be authored by github-actions[bot] and its checks will sit in 'action_required' until approved by hand. See README.adoc, 'Required repository secret'."
+          fi
+
       - name: Create milestone review PR
         uses: peter-evans/create-pull-request@v6
         with:
+          token: ${{ secrets.GHTOKEN || secrets.GITHUB_TOKEN }}
           commit-message: 'docs: milestone transition to ${{ needs.tag-version.outputs.next_phase }}'
           branch: gitbot/milestone-${{ needs.tag-version.outputs.next_version }}
           delete-branch: true

--- a/README.adoc
+++ b/README.adoc
@@ -65,7 +65,7 @@ git clone --recurse-submodules https://github.com/riscv/docs-spec-template.git &
 [IMPORTANT]
 ====
 **Instantiated via GitHub's "Use this template"?**
-GitHub does not populate submodule contents when creating a repository from a template. 
+GitHub does not populate submodule contents when creating a repository from a template.
 If `docs-resources` is empty, run `git submodule update --init --recursive` in your local workspace. The Makefile will also attempt to auto-initialize submodules on `make build`.
 ====
 

--- a/README.adoc
+++ b/README.adoc
@@ -164,6 +164,17 @@ All other versions are published as prereleases (`prerelease=true`).
 
 When a new tag crosses into a different phase than the previous tag, the bot opens a PR that updates `SPEC_STATE.md` for maintainer review. This PR is the checkpoint for governance/process updates required by the new phase.
 
+=== Required repository secret
+
+Set a `GHTOKEN` repository secret in every repository created from this template (Settings -> Secrets and variables -> Actions).
+
+Without it, the version bot and the release build fall back to the built-in `GITHUB_TOKEN`. GitHub refuses to let a `GITHUB_TOKEN`-authored pull request start further workflow runs, so every check on a bot-opened PR -- the PDF build, `pre-commit`, Vale, and the Antora content-source validation -- is created in the `action_required` state and waits for a maintainer to press "Approve and run". The PR itself is still correct; only its checks stall.
+
+`GHTOKEN` may be either:
+
+* A fine-grained personal access token scoped to the repository with `Contents: read and write`, `Pull requests: read and write`, and `Workflows: read and write`. Simplest to set up; tied to one person's account and expires.
+* A GitHub App installation token minted per run with `actions/create-github-app-token`. Preferred for repositories with more than one maintainer, since it is not tied to an individual.
+
 === Manual build overrides
 
 `workflow_dispatch` for `.github/workflows/build-pdf.yml` supports:


### PR DESCRIPTION
## Problem

The milestone PR step in `version-bot.yml` called `peter-evans/create-pull-request` with **no `token:` input**, so it fell back to the built-in `GITHUB_TOKEN`.

GitHub refuses to let a `GITHUB_TOKEN`-authored pull request start further workflow runs. The result is that every check on a bot-opened milestone PR — the PDF build, `pre-commit`, Vale, and the Antora content-source validation — is created in the `action_required` state and waits for a maintainer to press "Approve and run" on each push to the branch.

Observed downstream in a repo generated from this template: four runs parked on the bot's milestone PR, all `conclusion: action_required`, actor `github-actions[bot]`, while every `push` and `workflow_dispatch` run on the same repo completed normally.

## Changes

- Pass `token: ${{ secrets.GHTOKEN || secrets.GITHUB_TOKEN }}` to the milestone PR step, matching what `build-pdf.yml` already does in two places.
- Add a preflight step that emits a `::warning::` when `GHTOKEN` is unset. The `||` fallback is otherwise silent, and the failure mode looks like a working bot with permanently stalled checks. It warns rather than fails — without the secret the PR is still correct, only its checks stall, so failing the job would mean no PR at all.
- Document `GHTOKEN` in `README.adoc` under a new "Required repository secret" subsection, covering both the fine-grained PAT and GitHub App token options.

## Note for template consumers

`GHTOKEN` is referenced in six places across the workflows and was documented nowhere, so repositories created from this template had no way to know it was needed. This PR makes the requirement explicit, but each downstream repo still has to set the secret itself — the code change alone does not fix a repo where `GHTOKEN` is absent.

Existing bot PRs will not fix themselves either: their head commits are already authored by `github-actions[bot]`, so those checks need one manual approval. PRs opened after the secret is in place run unattended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)