### PR TITLE
ci: let the version tag trigger the release build

### DIFF
--- a/.github/workflows/version-bot.yml
+++ b/.github/workflows/version-bot.yml
@@ -46,6 +46,29 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # These credentials are what `git push origin "$next"` below signs the
+          # tag push with. A tag pushed by GITHUB_TOKEN cannot trigger the
+          # `push: tags: v*` run in build-pdf.yml, so the tag lands and no PDF
+          # or release is ever built. GHTOKEN makes it a real push event.
+          # Unlike milestone-pr, this job does not use create-pull-request, so
+          # persisting credentials here is safe.
+          token: ${{ secrets.GHTOKEN || secrets.GITHUB_TOKEN }}
+
+      # Both of this workflow's outputs -- the version tag and the milestone PR
+      # -- are inert when written by GITHUB_TOKEN, because GitHub refuses to let
+      # it start downstream runs. Checked in tag-version rather than milestone-pr
+      # so the warning appears on every run, not only at a milestone boundary.
+      # Warn rather than fail: the tag and PR are still correct, they just do
+      # not trigger anything.
+      - name: Check for bot token
+        env:
+          GHTOKEN: ${{ secrets.GHTOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "$GHTOKEN" ]]; then
+            echo "::warning::GHTOKEN is not set. The version tag will not trigger the release build in build-pdf.yml, and any milestone PR's checks will sit in 'action_required' until approved by hand. See README.adoc, 'Required repository secret'."
+          fi
 
       - name: Compute and tag next version
         id: version
@@ -164,22 +187,6 @@ jobs:
         run: |
           set -euo pipefail
           ./scripts/update-spec-state.sh "${{ needs.tag-version.outputs.next_version }}" "$(date +%Y-%m-%d)"
-
-      # A PR opened with GITHUB_TOKEN cannot trigger further workflow runs:
-      # GitHub parks them as `action_required` and a maintainer has to click
-      # "Approve and run" on every push to the branch. GHTOKEN gives the PR a
-      # real author so build-pdf/pre-commit/Vale/validate-content-source run on
-      # their own. Warn rather than fail -- without the secret the PR is still
-      # correct, its checks just need manual approval.
-      - name: Check for bot token
-        env:
-          GHTOKEN: ${{ secrets.GHTOKEN }}
-        run: |
-          set -euo pipefail
-
-          if [[ -z "$GHTOKEN" ]]; then
-            echo "::warning::GHTOKEN is not set. The milestone PR will be authored by github-actions[bot] and its checks will sit in 'action_required' until approved by hand. See README.adoc, 'Required repository secret'."
-          fi
 
       - name: Create milestone review PR
         uses: peter-evans/create-pull-request@v6

--- a/README.adoc
+++ b/README.adoc
@@ -123,12 +123,12 @@ The repository includes CI automation for specification revision metadata and st
 
 === Trigger for automated version bumps
 
-The version bot runs on pushes to `main` only when files under `src/**` change (the main specification content).
+The version bot is triggered manually, by `workflow_dispatch` on `.github/workflows/version-bot.yml`. Merging to `main` does not cut a version; a maintainer decides when to tag one.
 
 === End-to-end flow
 
-1. A commit that changes `src/**` is pushed to `main`.
-2. `.github/workflows/version-bot.yml` finds the latest `v*` tag and creates the next revision tag (`vMAJOR.MINOR`) for that commit.
+1. A maintainer dispatches `.github/workflows/version-bot.yml` against `main`.
+2. The bot finds the latest `v*` tag and creates the next revision tag (`vMAJOR.MINOR`) for the current `main` commit.
 3. The new tag triggers `.github/workflows/build-pdf.yml`.
 4. The build uses the tag as `:revnumber:` and sets `:revdate:` to the build date.
 5. `scripts/release-info.sh` derives phase (`:phase:`), display state (`:phase_display:`), warning text (`:phase_notice:`), and `:revremark:` from the version milestone.


### PR DESCRIPTION
The tag-version job checked out without a token override, so the credentials actions/checkout persisted were GITHUB_TOKEN, and that is what `git push origin "$next"` signed the tag push with. GitHub does not let a GITHUB_TOKEN-pushed tag start a `push: tags: v*` run, so build-pdf never fired: the tag landed and no PDF or GitHub Release was produced.

This is the same guard already worked around for the milestone PR, on the other of this workflow's two outputs. Pass GHTOKEN to the checkout so the tag push is a real push event. Persisting credentials is safe in this job -- the `persist-credentials: false` in milestone-pr exists only because create-pull-request supplies its own auth header.

Move the GHTOKEN warning from milestone-pr to tag-version and widen it to name both consequences. milestone-pr is gated on a milestone transition and is skipped on most runs, which is exactly when a missing secret would otherwise go unreported.

Also correct README.adoc: it described the bot as running on pushes to main that touch src/**, which has not been true since eb0941c moved the project to manual release tagging. The workflow is workflow_dispatch only.