### PR TITLE
fix(build): emit ARC PDF filename from AsciiDoctor instead of renaming after the build

### DIFF
--- a/ARC_SUBMISSION.md
+++ b/ARC_SUBMISSION.md
@@ -182,16 +182,17 @@ ls build/
 # → <short>-v0.8-20260612.pdf
 ```
 
-The `arc-rename` target in the Makefile produces the ARC-compliant filename
-on every build — there is no separate "ARC build" target; every PDF this
-repo emits is ARC-compliant by construction.
+The Makefile passes the ARC-compliant filename to AsciiDoctor's `-o` on every
+build — there is no separate "ARC build" target, and no post-build rename that
+could fail and leave a non-compliant PDF behind; every PDF this repo emits is
+ARC-compliant by construction.
 
 ### 4.3 Multi-document repos
 
 If your repo builds more than one specification, list each in `DOCS` and
-the `arc-rename` target renames each PDF with its own basename. If two
-docs in one repo are submitted to ARC independently, ensure their
-basenames are the ARC short names.
+the `%.pdf` rule names each PDF from its own basename. If two docs in one
+repo are submitted to ARC independently, ensure their basenames are the
+ARC short names.
 
 ## 5. Pre-submission checklist
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -125,28 +125,27 @@ v1.0       phase=ratified               display=Ratified
       -a milestone_id='${MILESTONE_ID}' \
       -a spec_short='${SPEC_SHORT}' \
       ```
-- [ ] Add the `arc-rename` target and make `build-docs` depend on it:
+- [ ] Have AsciiDoctor emit the ARC filename directly (`-o` resolves relative to
+      `-D`). Do NOT rename the PDF after the fact: inside the container `build/`
+      is created by root, so a host-side `mv` into it fails with EPERM on rootful
+      Docker — and a rename that fails after a green build ships a
+      non-ARC-compliant asset.
       ```make
-      .PHONY: ... arc-rename
+      ARC_PDF = $(1)-v$(VERSION_NUM)-$(DATE_STAMP).pdf
 
-      build-docs: $(DOCS_PDF) $(DOCS_HTML) arc-rename
+      build-docs: $(DOCS_PDF) $(DOCS_HTML)
 
-      arc-rename: $(DOCS_PDF)
-      	@for pdf in $(DOCS_PDF); do \
-      		base=$$(basename $$pdf .pdf); \
-      		dest="$$base-v$(VERSION_NUM)-$(DATE_STAMP).pdf"; \
-      		if [ -f build/$$pdf ]; then \
-      			mv build/$$pdf build/$$dest; \
-      			echo "ARC submission PDF: build/$$dest"; \
-      		fi; \
-      	done
+      %.pdf: %.adoc
+      	$(DOCKER_CMD) $(DOCKER_QUOTE) $(ASCIIDOCTOR_PDF) $(OPTIONS) $(REQUIRES) -o $(call ARC_PDF,$*) $< $(DOCKER_QUOTE)
+      	@test -f build/$(call ARC_PDF,$*) || { echo "ERROR: build/$(call ARC_PDF,$*) was not produced" >&2; exit 1; }
+      	@echo "ARC submission PDF: build/$(call ARC_PDF,$*)"
       ```
 
 Smoke test (no Docker required):
 ```bash
-make -n SKIP_DOCKER=true VERSION=v0.8 DATE=2026-06-12 | grep -E "(asciidoctor|ARC|dest=)"
+make -n SKIP_DOCKER=true VERSION=v0.8 DATE=2026-06-12 | grep -E "(asciidoctor|ARC)"
 ```
-Should show `dest="<short>-v0.8-20260612.pdf"`.
+Should show `-o spec-sample-v0.8-20260612.pdf` on the `asciidoctor-pdf` line.
 
 ## Step 3 — Update `.github/workflows/build-pdf.yml`
 
@@ -489,13 +488,14 @@ When you're ready to advance to the next milestone:
   PDF named per §3.2 of `ARC_SUBMISSION.md` and a title page per §3.3.
   Adopting the template Makefile is the easiest way; otherwise replicate the
   naming logic in whatever build system you use.
-- **Multi-document repos:** the `arc-rename` target loops over every PDF in
-  `$(DOCS_PDF)`, so each gets renamed with its own basename + version + date.
+- **Multi-document repos:** the `%.pdf` rule fires once per PDF in
+  `$(DOCS_PDF)`, so each is named from its own basename + version + date.
   If two docs in one repo need to be ARC-submitted independently, the
   `SPEC_SHORT` heuristic uses the .adoc basename — verify that's the short
   name ARC expects.
 - **GitHub Actions caching:** if you cache `build/` between runs, clear the
-  cache once so the old un-renamed PDF doesn't ghost the renamed output.
+  cache once so a stale PDF from an earlier version doesn't ghost the current
+  output — the release step globs `build/*.pdf` and would attach both.
 - **Don't rewrite tags.** Push a new monotonically-greater tag if you need to
   reissue.
 - **`:toc: macro` requires explicit placement.** If you switch from

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ REQUIRES := --require=asciidoctor-bibtex \
 
 DOCS_RESOURCES_CONFIG := docs-resources/global-config.adoc
 
-.PHONY: all build clean build-container build-no-container build-docs arc-rename stamp-antora check-docs-resources
+.PHONY: all build clean build-container build-no-container build-docs stamp-antora check-docs-resources
 
 all: build
 
@@ -106,25 +106,24 @@ check-docs-resources:
 stamp-antora:
 	./scripts/stamp-antora-version.sh "$(VERSION)" "$(DATE)"
 
-# After AsciiDoctor produces build/<basename>.pdf, rename each PDF to the
-# ARC-compliant form <basename>-v<version>-<YYYYMMDD>.pdf so every build
-# (local or CI) emits a uniquely identifiable artifact.
-build-docs: check-docs-resources $(DOCS_PDF) $(DOCS_HTML) arc-rename
+build-docs: check-docs-resources $(DOCS_PDF) $(DOCS_HTML)
 
-arc-rename: $(DOCS_PDF)
-	@for pdf in $(DOCS_PDF); do \
-		base=$$(basename $$pdf .pdf); \
-		dest="$$base-v$(VERSION_NUM)-$(DATE_STAMP).pdf"; \
-		if [ -f build/$$pdf ]; then \
-			mv build/$$pdf build/$$dest; \
-			echo "ARC submission PDF: build/$$dest"; \
-		fi; \
-	done
+# ARC-compliant PDF name: <basename>-v<version>-<YYYYMMDD>.pdf, so every build
+# (local or CI) emits a uniquely identifiable artifact.
+ARC_PDF = $(1)-v$(VERSION_NUM)-$(DATE_STAMP).pdf
 
 vpath %.adoc $(SRC_DIR)
 
+# AsciiDoctor writes the ARC name itself (-o is resolved relative to -D), rather
+# than the build renaming build/<basename>.pdf afterwards. Inside the container
+# build/ is created by root, so a host-side `mv` into it fails with EPERM on
+# rootful Docker -- which is exactly how v0.61 shipped a non-compliant
+# build/spec-sample.pdf while the log claimed the ARC name. Naming it at the
+# source removes the failure mode instead of reporting it.
 %.pdf: %.adoc
-	$(DOCKER_CMD) $(DOCKER_QUOTE) $(ASCIIDOCTOR_PDF) $(OPTIONS) $(REQUIRES) $< $(DOCKER_QUOTE)
+	$(DOCKER_CMD) $(DOCKER_QUOTE) $(ASCIIDOCTOR_PDF) $(OPTIONS) $(REQUIRES) -o $(call ARC_PDF,$*) $< $(DOCKER_QUOTE)
+	@test -f build/$(call ARC_PDF,$*) || { echo "ERROR: build/$(call ARC_PDF,$*) was not produced" >&2; exit 1; }
+	@echo "ARC submission PDF: build/$(call ARC_PDF,$*)"
 
 %.html: %.adoc
 	$(DOCKER_CMD) $(DOCKER_QUOTE) $(ASCIIDOCTOR_HTML) $(OPTIONS) $(REQUIRES) $< $(DOCKER_QUOTE)


### PR DESCRIPTION
## Problem

The `v0.61` release in `riscv/spec-template-test` (a repo seeded from this template) published `spec-sample.pdf`, not the ARC-compliant
`spec-sample-v0.61-20260731.pdf` that §3.2 of `ARC_SUBMISSION.md` requires.

The build log shows why — and shows it reporting success anyway:

```
mv: cannot move 'build/spec-sample.pdf' to 'build/spec-sample-v0.61-20260731.pdf': Permission denied
ARC submission PDF: build/spec-sample-v0.61-20260731.pdf
```

Two compounding causes:

1. The container mounts the workspace and creates `build/` as **root**, so the
   host-side `mv` in `arc-rename` cannot write into that directory under rootful
   Docker (GitHub's runners). Rootless Docker/podman map container root to the
   invoking user, which is why this never reproduces locally.
2. The `mv` sat inside a `for` loop whose last command was the success `echo`, so
   the recipe exited 0. `make` printed "Build completed successfully", the log
   printed the ARC filename it had *not* produced, and the release step
   (`files: build/*.pdf`) attached the unrenamed PDF.

Net effect: a silent ARC-compliance failure on a green release.

## Fix

Let AsciiDoctor write the ARC name itself — `-o` is resolved relative to `-D`, so
no host-side write into `build/` remains to fail:

```make
ARC_PDF = $(1)-v$(VERSION_NUM)-$(DATE_STAMP).pdf

%.pdf: %.adoc
	$(DOCKER_CMD) $(DOCKER_QUOTE) $(ASCIIDOCTOR_PDF) $(OPTIONS) $(REQUIRES) -o $(call ARC_PDF,$*) $< $(DOCKER_QUOTE)
	@test -f build/$(call ARC_PDF,$*) || { echo "ERROR: ... was not produced" >&2; exit 1; }
```

The `arc-rename` target is removed. The `test -f` guard means a missing artifact
now fails the build instead of echoing a filename that isn't there.

Every PDF is ARC-named by construction, including a bare `make spec-sample.pdf`.

## Docs updated

- `ARC_SUBMISSION.md` §4.2 / §4.3 — mechanism description and multi-doc note
- `MIGRATION.md` — checklist snippet, smoke test, multi-doc and CI-caching notes

## Verification

Real container build (not a dry run):

```
$ make VERSION=v0.8 DATE=2026-06-12
ARC submission PDF: build/spec-sample-v0.8-20260612.pdf
$ ls build/
spec-sample-v0.8-20260612.pdf  spec-sample.html
```

`-o`'s resolution against `-D` was confirmed against `riscvintl/riscv-docs-base-container-image:latest` rather than assumed.

## Not in scope

- The already-published `v0.61` asset still has the wrong name; correcting it
  needs a rebuild against the tag plus deletion of the stale asset (the release
  step globs `build/*.pdf` and would otherwise attach both).
- `make clean` has the same root-owned-`build/` problem under rootful Docker, but
  it fails loudly and CI never hits it on a fresh checkout.
- The build still renders `build/spec-sample.html` that nothing consumes — not
  the artifact upload, not the release. Separate decision: attach it (with ARC
  naming) or drop the `$(DOCS_HTML)` dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
