### PR TITLE
Publish the Antora HTML site to GitHub Pages

### DIFF
--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -13,8 +13,12 @@ name: Publish site to GitHub Pages
 # ship centrally. The build itself lives in scripts/build-pages-site.sh so it can
 # be reproduced locally.
 #
-# One-time setup in a repo seeded from this template: none. The configure-pages
-# step below enables Pages (with the "GitHub Actions" source) on first run.
+# One-time setup in a repo seeded from this template: a repository admin must set
+# Settings -> Pages -> Source to "GitHub Actions". The configure-pages step below
+# asks for that automatically (enablement: true) and it works wherever the
+# organization permits it, but the RISC-V org restricts Pages site creation, so
+# the workflow token is refused there with "Resource not accessible by
+# integration". Once the site exists, enablement is a no-op.
 
 on:
   push:

--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -20,6 +20,16 @@ on:
   push:
     tags:
       - v*
+    # ===================================================================
+    # TEMPORARY -- REMOVE BEFORE MERGING.
+    # Exercises this workflow end to end (Pages enablement, build, deploy)
+    # from the feature branch. workflow_dispatch cannot do that yet: the
+    # "Run workflow" button only appears once the file is on the default
+    # branch, and pushing a v* tag to test would also fire build-pdf.yml
+    # and cut a real release of the template.
+    # ===================================================================
+    branches:
+      - publish-to-pages
   # Republish on demand -- e.g. after fixing content on a release, or to bring up
   # the site in a freshly seeded repo without waiting for the first tag.
   workflow_dispatch:

--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -24,16 +24,6 @@ on:
   push:
     tags:
       - v*
-    # ===================================================================
-    # TEMPORARY -- REMOVE BEFORE MERGING.
-    # Exercises this workflow end to end (Pages enablement, build, deploy)
-    # from the feature branch. workflow_dispatch cannot do that yet: the
-    # "Run workflow" button only appears once the file is on the default
-    # branch, and pushing a v* tag to test would also fire build-pdf.yml
-    # and cut a real release of the template.
-    # ===================================================================
-    branches:
-      - publish-to-pages
   # Republish on demand -- e.g. after fixing content on a release, or to bring up
   # the site in a freshly seeded repo without waiting for the first tag.
   workflow_dispatch:

--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -1,0 +1,147 @@
+---
+name: Publish site to GitHub Pages
+
+# Publish this specification as a standalone Antora HTML site on this
+# repository's own GitHub Pages site, alongside the release PDF.
+#
+# Relationship to the RISC-V production site: docs.riscv.org is assembled by the
+# central playbook (github.com/riscv-admin/antora.riscv.org) from 20+ content
+# sources, of which this repo is one -- that site is canonical for RISC-V specs
+# and is NOT built here (see ANTORA.md "Production model"). What this workflow
+# publishes is a per-repo copy of the same content, which is the primary output
+# for a repo seeded from this template but is a convenience for specs that also
+# ship centrally. The build itself lives in scripts/build-pages-site.sh so it can
+# be reproduced locally.
+#
+# One-time setup in a repo seeded from this template: none. The configure-pages
+# step below enables Pages (with the "GitHub Actions" source) on first run.
+
+on:
+  push:
+    tags:
+      - v*
+  # Republish on demand -- e.g. after fixing content on a release, or to bring up
+  # the site in a freshly seeded repo without waiting for the first tag.
+  workflow_dispatch:
+
+# contents: read      -- checkout only; this workflow never writes to the repo.
+#                        In particular it does NOT commit the version stamp: the
+#                        stamp is applied to the working tree for the build and
+#                        thrown away (build-pdf.yml owns committing it to main).
+# pages/id-token      -- required by actions/deploy-pages (OIDC deployment).
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Never let two publishes race for the single Pages deployment. Queue rather
+# than cancel: a cancelled release publish would leave the previous version live
+# with no indication that the newer one never shipped.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    # GitHub Pages is not available on private repositories outside GitHub Team
+    # and Enterprise Cloud. A template consumer working in a private repo should
+    # skip cleanly rather than see a failed release run; on Team/Enterprise,
+    # delete this condition to publish privately.
+    if: ${{ !github.event.repository.private }}
+
+    runs-on: ubuntu-latest
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+
+    # Local Kroki server for asciidoctor-kroki (wavedrom etc.). Matches the
+    # kroki-server-url: http://localhost:9870 attribute in antora-playbook.yml,
+    # which the generated Pages playbook inherits. Pinned for reproducible
+    # diagram output -- keep in sync with docker-compose.yml and
+    # validate-content-source.yml.
+    services:
+      kroki:
+        image: yuzutech/kroki:0.31.1
+        ports:
+          - 9870:8000
+
+    steps:
+      # fetch-depth: 0 -- scripts/release-info.sh resolves the version from tags,
+      # and the site build inspects every release tag to decide which versions to
+      # publish. submodules -- docs-resources supplies the cover logo.
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install Antora tooling
+        run: npm ci
+
+      # The service container is "started" before it can serve; without this the
+      # Antora build can race Kroki's JVM startup and fail on diagram rendering.
+      # Polled from the runner (which has curl) rather than via a container
+      # healthcheck, since the Kroki image ships no HTTP client to probe itself.
+      - name: Wait for Kroki
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 30); do
+            if curl -fsS http://localhost:9870/health >/dev/null 2>&1; then
+              echo "Kroki is up after ${i} attempt(s)."
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::Kroki did not become healthy within 60s"
+          exit 1
+
+      # Enables Pages on first run (enablement: true) and reports the base URL
+      # the site will be served from. Project sites live under /<repo>/, not at
+      # the domain root, so Antora needs this for the sitemap and canonical URLs.
+      - name: Configure Pages
+        id: pages
+        uses: actions/configure-pages@v5
+        with:
+          enablement: true
+
+      # Version/date resolution mirrors build-pdf.yml so the published site
+      # version matches the released PDF. On a tag push the tag IS the version;
+      # the date is taken from the tagged commit rather than "today" so that
+      # re-running this workflow later republishes an identical site. A manual
+      # run leaves both empty, and the script falls back to release-info.sh.
+      - name: Resolve release version
+        id: release
+        run: |
+          set -euo pipefail
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            version="${{ github.ref_name }}"
+            date="$(git log -1 --format=%cs "${{ github.ref_name }}")"
+          else
+            version=""
+            date=""
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "date=$date" >> "$GITHUB_OUTPUT"
+          echo "Publishing version='${version:-<from tags>}' date='${date:-<today>}'"
+
+      - name: Build site
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+          DATE: ${{ steps.release.outputs.date }}
+        run: ./scripts/build-pages-site.sh "${{ steps.pages.outputs.base_url }}"
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: build/pages-site
+
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@
 # regenerated every build, never committed.
 _images/
 /src/images/
+# GitHub Pages build artifacts (scripts/build-pages-site.sh): the playbook it
+# derives from antora-playbook.yml, and the cover logo it stages out of the
+# docs-resources submodule. Both are regenerated on every build.
+/antora-pages-playbook.yml
+/modules/ROOT/images/risc-v_logo.svg

--- a/ANTORA.md
+++ b/ANTORA.md
@@ -136,6 +136,31 @@ that `validate-content-source.yml` exception-lists.
 
 ### Versions, and why only one is published today
 
+### Untagged builds publish as `dev`
+
+A build with no release tag to name it — the first manual publish in a freshly
+seeded repo, or any `workflow_dispatch` before the first tag — gets
+`release-info.sh`'s dev version, `vX.YY-<sha>-<date>`. That string is published
+under a short fixed label (`dev`, override with `DEV_VERSION_LABEL`) instead of
+verbatim, for two reasons:
+
+1. **It breaks the navigation.** The RISC-V UI floats the version selector
+   beside the nav tree (`.version-box{float:right}` plus
+   `.nav-version-group{overflow:hidden}`, which establishes a block formatting
+   context), so the nav only gets the width left over next to the selector, and
+   the selector is as wide as its longest version string. At 22 characters the
+   nav collapses to about three characters per line. Release tags are short
+   (`vX.Y`) and render correctly, so this never affects a real release.
+2. **It churns URLs.** Every dispatch would otherwise mint a
+   `/spec-sample/<sha>/` path that the next publish orphans, since each deploy
+   replaces the whole site. `/spec-sample/dev/` stays linkable.
+
+The full dev version is not lost: it is still stamped into `page-revnumber` and
+shown on the cover page, so a published dev site names the exact commit it came
+from.
+
+### Version stamping
+
 The version stamp is applied to the **working tree** at build time from
 `scripts/release-info.sh` — the same source the PDF uses — so the published
 version matches the PDF even though the tagged commit's committed `antora.yml`

--- a/ANTORA.md
+++ b/ANTORA.md
@@ -98,8 +98,14 @@ this is the primary HTML output; for specs that *are* consumed centrally,
 - Workflow: `.github/workflows/publish-site.yml` — runs on `v*` tag pushes and on
   manual dispatch, and deploys via `actions/deploy-pages`.
 - Build: `scripts/build-pages-site.sh` — the whole build, runnable locally.
-- Setup in a seeded repo: **none**. `actions/configure-pages` with
-  `enablement: true` turns Pages on (source: "GitHub Actions") on the first run.
+- Setup in a seeded repo: **one manual step**. `actions/configure-pages` is
+  configured with `enablement: true` and will turn Pages on by itself wherever
+  it is allowed to — but the RISC-V organization restricts Pages site creation,
+  so the workflow token is refused with `Resource not accessible by integration`
+  and a repository admin must set *Settings → Pages → Source* to "GitHub
+  Actions" once. Equivalent API call, with an admin token:
+  `gh api -X POST repos/<org>/<repo>/pages -f build_type=workflow`. Once the
+  site exists, `enablement: true` is a no-op and releases publish unattended.
   The job skips itself on private repos, where Pages needs Team/Enterprise.
 
 ### How the playbook is derived

--- a/ANTORA.md
+++ b/ANTORA.md
@@ -87,6 +87,72 @@ first — Antora fetches from GitHub, not the worktree):
 
 No `nav:` key needed (declared in `antora.yml`). Renders at `/spec-sample/`.
 
+## Publishing to GitHub Pages
+
+Separate from the central site, this repo also publishes a **standalone copy** of
+the same content to its own GitHub Pages site, next to the release PDF. For a
+repo seeded from this template that is not part of the RISC-V central library,
+this is the primary HTML output; for specs that *are* consumed centrally,
+`docs.riscv.org` stays canonical and this is a convenience.
+
+- Workflow: `.github/workflows/publish-site.yml` — runs on `v*` tag pushes and on
+  manual dispatch, and deploys via `actions/deploy-pages`.
+- Build: `scripts/build-pages-site.sh` — the whole build, runnable locally.
+- Setup in a seeded repo: **none**. `actions/configure-pages` with
+  `enablement: true` turns Pages on (source: "GitHub Actions") on the first run.
+  The job skips itself on private repos, where Pages needs Team/Enterprise.
+
+### How the playbook is derived
+
+The Pages build does **not** get its own committed playbook. `antora-playbook.yml`
+carries a hand-maintained mirror of the central playbook's rendering attributes,
+and a second copy of that block would silently drift. Instead
+`scripts/gen-pages-playbook.js` loads it and overrides four things into a
+generated, gitignored `antora-pages-playbook.yml`:
+
+| Key | Why |
+| --- | --- |
+| `site.url` | Project Pages sites live at `https://<org>.github.io/<repo>/`, not at a domain root; Antora needs the base path for the sitemap and canonical links. |
+| `content.sources` | Which versions to publish (below). |
+| `output.dir` | `build/pages-site`, so a publish never clobbers the `build/site` preview output. |
+| `cover-logo` | Resolves the cover logo locally instead of from `common::`. |
+
+### The cover logo
+
+`index.adoc` renders the logo through the `cover-logo` attribute rather than a
+literal resource ID. It defaults in `antora.yml` to `common::risc-v_logo.svg`,
+the shared asset the central build uses. A single-repo build has no `common`
+component, so the Pages build stages the copy from the `docs-resources` submodule
+into `modules/ROOT/images/` (gitignored) and hard-sets the attribute to it. The
+central build is unaffected, and the local-preview behaviour is unchanged — a
+bare `npm run preview` still logs the one expected unresolved `common::` image
+that `validate-content-source.yml` exception-lists.
+
+### Versions, and why only one is published today
+
+The version stamp is applied to the **working tree** at build time from
+`scripts/release-info.sh` — the same source the PDF uses — so the published
+version matches the PDF even though the tagged commit's committed `antora.yml`
+has not been stamped yet. Nothing is committed back; `build-pdf.yml` still owns
+stamping `main`.
+
+The build also scans release tags and publishes any that carry a correctly
+stamped descriptor, which is what would give the site a multi-version dropdown. A
+tag qualifies only if it contains an `antora.yml` whose `version:` equals the tag
+itself. That is deliberately strict, for two reasons:
+
+1. Antora **aborts the entire build** on any ref that has no `antora.yml`, so
+   tags predating the Antora layout must be filtered out.
+2. A tag stamped with a different version would publish under a wrong or
+   duplicate version path.
+
+**Today no tag qualifies**, so the site publishes exactly one version. The reason
+is ordering: a release tag is pushed *first*, and `build-pdf.yml` stamps
+`antora.yml` on `main` *afterwards* — so a tag never contains its own version.
+If the release flow is ever changed to stamp and commit **before** cutting the
+tag, past releases begin appearing in the version dropdown automatically, with no
+change to this script.
+
 ## Section numbering
 
 Chapter/section numbering is applied by the **central playbook**, not this repo.
@@ -271,4 +337,9 @@ npm install                   # one-time: Antora + kroki/mathjax extensions
 docker compose up -d kroki    # local Kroki server on :9870 (for wavedrom/diagrams)
 npm run preview               # antora --fetch antora-playbook.yml -> build/site/
 docker compose down           # stop Kroki when done
+
+# GitHub Pages site, exactly as CI builds it (needs Kroki up, as above).
+# NOTE: this stamps antora.yml in your worktree -- pass NO_STAMP=1 to leave it be.
+NO_STAMP=1 ./scripts/build-pages-site.sh            # -> build/pages-site/
+./scripts/build-pages-site.sh https://org.github.io/repo   # with the real base URL
 ```

--- a/README.adoc
+++ b/README.adoc
@@ -125,6 +125,23 @@ To check bibliography output, build with `make` (the PDF/HTML use the `asciidoct
 **Don't forget site numbering rules.** Chapter/section numbering on the published site is applied by the RISC-V central playbook, keyed to the **line numbers of the `xref` entries in `modules/ROOT/nav.adoc`** — not by anything in this repo. When you finalize your chapter structure (or add/remove/reorder pages in `nav.adoc`), you must add or update the matching entry in the central playbook's `numbering_rules`, or your spec will render with wrong or missing chapter numbers. See the *Section numbering* section of link:ANTORA.md[ANTORA.md] for the exact rule and format.
 ====
 
+=== Publishing the Antora site to GitHub Pages
+
+Every `v*` release tag also publishes the specification as an HTML site on this repository's own GitHub Pages site, alongside the release PDF, via `.github/workflows/publish-site.yml`. Nothing needs to be enabled by hand — the workflow turns Pages on (source: *GitHub Actions*) the first time it runs, and the site lands at `https://<org>.github.io/<repo>/`.
+
+The site version is stamped from the same source as the PDF, so the two always match. To build exactly what CI publishes, without touching your `antora.yml`:
+
+[source,shell]
+----
+docker compose up -d kroki                # local diagram server, as above
+NO_STAMP=1 ./scripts/build-pages-site.sh  # builds the site into build/pages-site/
+----
+
+[NOTE]
+====
+This per-repo site is **not** the canonical RISC-V documentation site. `docs.riscv.org` is assembled centrally from many spec repositories; this workflow publishes a standalone copy of the same content, which is the primary HTML output for a spec that is not part of the central library. It also currently publishes a **single version** rather than a version dropdown — see *Publishing to GitHub Pages* in link:ANTORA.md[ANTORA.md] for why, and what would change that.
+====
+
 == Automated Versioning and Milestones
 
 The repository includes CI automation for specification revision metadata and state transitions.

--- a/README.adoc
+++ b/README.adoc
@@ -38,6 +38,9 @@ When instantiating a new repository from this template, perform these one-time s
    *(Alternatively, configure a repository secret named `GHTOKEN` with a Personal Access Token).*
 2. **Initialize Submodules**:
    Run `git submodule update --init --recursive` in your local workspace.
+3. **Enable GitHub Pages** (only if you want the published HTML site):
+   Go to *Settings* -> *Pages* -> *Build and deployment* -> Set *Source* to *GitHub Actions*.
+   The publish workflow attempts this automatically, but the RISC-V organization restricts Pages site creation, so the workflow's built-in token cannot do it — a repository admin must do it once by hand. After that, every release publishes without further intervention.
 
 == Building the Document
 
@@ -127,7 +130,9 @@ To check bibliography output, build with `make` (the PDF/HTML use the `asciidoct
 
 === Publishing the Antora site to GitHub Pages
 
-Every `v*` release tag also publishes the specification as an HTML site on this repository's own GitHub Pages site, alongside the release PDF, via `.github/workflows/publish-site.yml`. Nothing needs to be enabled by hand — the workflow turns Pages on (source: *GitHub Actions*) the first time it runs, and the site lands at `https://<org>.github.io/<repo>/`.
+Every `v*` release tag also publishes the specification as an HTML site on this repository's own GitHub Pages site, alongside the release PDF, via `.github/workflows/publish-site.yml`. The site lands at `https://<org>.github.io/<repo>/`.
+
+This needs the one-time *Enable GitHub Pages* step from the <<Repository Setup Checklist>> above. The workflow tries to enable Pages itself, but the RISC-V organization restricts Pages site creation, so its token is refused (`Resource not accessible by integration`) and a repository admin has to set the source to *GitHub Actions* once by hand. Everything after that is automatic.
 
 The site version is stamped from the same source as the PDF, so the two always match. To build exactly what CI publishes, without touching your `antora.yml`:
 

--- a/README.adoc
+++ b/README.adoc
@@ -134,7 +134,9 @@ Every `v*` release tag also publishes the specification as an HTML site on this 
 
 This needs the one-time *Enable GitHub Pages* step from the <<Repository Setup Checklist>> above. The workflow tries to enable Pages itself, but the RISC-V organization restricts Pages site creation, so its token is refused (`Resource not accessible by integration`) and a repository admin has to set the source to *GitHub Actions* once by hand. Everything after that is automatic.
 
-The site version is stamped from the same source as the PDF, so the two always match. To build exactly what CI publishes, without touching your `antora.yml`:
+The site version is stamped from the same source as the PDF, so the two always match. A build with no release tag to name it — such as the first manual run in a new repository — publishes under `/spec-sample/dev/` rather than a long `vX.YY-<sha>-<date>` path, which keeps the URL stable and the site navigation readable; the exact commit is still shown on the cover page.
+
+To build exactly what CI publishes, without touching your `antora.yml`:
 
 [source,shell]
 ----

--- a/antora.yml
+++ b/antora.yml
@@ -36,6 +36,14 @@ asciidoc:
     # as raw text. This is a spec-SPECIFIC resource the central playbook cannot
     # supply, so it legitimately belongs here (not a rendering-attribute override).
     asamBibliography: ROOT:resources/riscv-spec.bib
+    # Cover logo for index.adoc, as an Antora resource ID. The default is the
+    # shared asset from the central `common` component, which is what the
+    # riscv.org production build uses. A single-repo build has no `common`
+    # component, so scripts/build-pages-site.sh (GitHub Pages) hard-sets this in
+    # its generated playbook to a copy vendored from the docs-resources
+    # submodule. Indirection lives here so neither build has to special-case the
+    # page itself.
+    cover-logo: common::risc-v_logo.svg
     # Release metadata for the cover page (index.adoc), kept in lockstep with the
     # PDF title page. Spec-SPECIFIC (the central playbook cannot know this spec's
     # version/phase), so it belongs here -- like asamBibliography above, not a

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -7,14 +7,17 @@
 //
 // The cover treatment below (logo, title, version, phase banner) mirrors the
 // ratified RISC-V specs (e.g. riscv-server-platform) so this spec renders with a
-// proper cover on the site. `common::risc-v_logo.svg` is a shared asset supplied
-// by the central playbook, so it resolves only on the site build; a bare local
-// `npm run preview` has no `common` component and logs one expected unresolved
-// image. CI exception-lists that, which also means CI cannot validate this macro
-// -- check it on the dev site after publishing.
+// proper cover on the site. The logo comes from the `cover-logo` attribute
+// (antora.yml), which defaults to `common::risc-v_logo.svg` -- a shared asset
+// supplied by the central playbook, so it resolves only on the central site
+// build. A bare local `npm run preview` has no `common` component and logs one
+// expected unresolved image; CI exception-lists that, which also means CI cannot
+// validate this macro -- check it on the dev site after publishing. The GitHub
+// Pages build (scripts/build-pages-site.sh) overrides the attribute with a
+// vendored copy, so its cover renders standalone.
 
 [.space-below]
-image::common::risc-v_logo.svg[id="riscvlogo",role="xs",alt="RISCV"]
+image::{cover-logo}[id="riscvlogo",role="xs",alt="RISCV"]
 
 
 

--- a/scripts/build-pages-site.sh
+++ b/scripts/build-pages-site.sh
@@ -19,6 +19,8 @@
 #   DATE      Release date, YYYY-MM-DD (default: today)
 #   NO_STAMP  Set to 1 to skip version stamping (leave antora.yml as committed)
 #   TAG_GLOB  Which tags to consider publishing (default: v*)
+#   DEV_VERSION_LABEL
+#             Version label for untagged builds (default: dev) -- see step 1b
 set -euo pipefail
 
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -27,6 +29,7 @@ cd "$repo_root"
 
 site_url="${1:-}"
 tag_glob="${TAG_GLOB:-v*}"
+DEV_VERSION_LABEL="${DEV_VERSION_LABEL:-dev}"
 generated_playbook="$repo_root/antora-pages-playbook.yml"
 output_dir="./build/pages-site"
 
@@ -53,6 +56,36 @@ else
 fi
 head_version="$(descriptor_version < "$repo_root/antora.yml")"
 echo "    component version: ${head_version:-<none>}"
+
+# ---------------------------------------------------------------------------
+# 1b. Keep the published version string SHORT
+#
+# The RISC-V UI floats the version selector alongside the navigation tree
+# (.version-box{float:right} + .nav-version-group{overflow:hidden}), so the nav
+# gets only the width left over beside the selector, and the selector is as wide
+# as its longest version string. A release tag is short (vX.Y) and renders fine.
+# An UNTAGGED build is not: release-info.sh returns a dev version of the form
+# vX.YY-<sha>-<date> (22 chars), which squeezes the nav to about three
+# characters per line -- and that is exactly what the first manual publish in a
+# freshly seeded repo produces.
+#
+# So untagged builds publish under a short, fixed label. This also stops every
+# dispatch from minting a brand-new /spec-sample/<sha>/ path that the next
+# publish orphans; /spec-sample/dev/ stays linkable. The full dev version is
+# still recorded on the cover page, via the page-revnumber stamped above.
+# ---------------------------------------------------------------------------
+case "$head_version" in
+  *-*)
+    echo "    untagged build -- publishing as '$DEV_VERSION_LABEL' (cover keeps $head_version)"
+    tmp_yml="$(mktemp)"
+    awk -v label="$DEV_VERSION_LABEL" '
+      !done && /^version:/ { print "version: " label; done = 1; next }
+      { print }
+    ' "$repo_root/antora.yml" > "$tmp_yml"
+    mv "$tmp_yml" "$repo_root/antora.yml"
+    head_version="$DEV_VERSION_LABEL"
+    ;;
+esac
 
 # ---------------------------------------------------------------------------
 # 2. Stage the cover logo

--- a/scripts/build-pages-site.sh
+++ b/scripts/build-pages-site.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Build the standalone Antora HTML site that this repo publishes to its own
+# GitHub Pages site (see .github/workflows/publish-site.yml).
+#
+# This is NOT the riscv.org production site. The production site is assembled by
+# the central playbook (github.com/riscv-admin/antora.riscv.org) from 20+ content
+# sources, of which this repo is one; see ANTORA.md "Production model". What this
+# script builds is a self-contained, per-repo copy of the same content -- useful
+# on its own for a repo seeded from this template, and useful here as a
+# full-fidelity preview of how the content renders.
+#
+# Usage: scripts/build-pages-site.sh [site-url]
+#   site-url  Base URL the site is served from, e.g. https://riscv.github.io/my-spec
+#             (GitHub Actions passes the actions/configure-pages base_url).
+#             Omitted for local runs -- the playbook's own site.url is kept.
+#
+# Environment:
+#   VERSION   Release version to stamp (default: scripts/release-info.sh version)
+#   DATE      Release date, YYYY-MM-DD (default: today)
+#   NO_STAMP  Set to 1 to skip version stamping (leave antora.yml as committed)
+#   TAG_GLOB  Which tags to consider publishing (default: v*)
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$here/.." && pwd)"
+cd "$repo_root"
+
+site_url="${1:-}"
+tag_glob="${TAG_GLOB:-v*}"
+generated_playbook="$repo_root/antora-pages-playbook.yml"
+output_dir="./build/pages-site"
+
+# Read the value of a top-level `version:` key out of an antora.yml on stdin.
+descriptor_version() {
+  awk '/^version:/ { gsub(/^[ \t]*version:[ \t]*/, ""); gsub(/^["'\'']|["'\'']$/, ""); print; exit }'
+}
+
+# ---------------------------------------------------------------------------
+# 1. Version stamp
+#
+# Antora reads a STATIC version from antora.yml, and the ARC Author Guide
+# requires the HTML site version to match the PDF exactly. Stamp the WORKTREE
+# from scripts/release-info.sh -- the same source the PDF build uses -- so the
+# published version is right even when the checked-out commit's committed
+# antora.yml has not been stamped yet (on a tag push, the release workflow
+# stamps main only AFTER the tag exists). The edit is never committed here.
+# ---------------------------------------------------------------------------
+if [ "${NO_STAMP:-0}" = "1" ]; then
+  echo "==> Skipping version stamp (NO_STAMP=1)"
+else
+  echo "==> Stamping antora.yml"
+  "$here/stamp-antora-version.sh" "${VERSION:-}" "${DATE:-$(date +%Y-%m-%d)}"
+fi
+head_version="$(descriptor_version < "$repo_root/antora.yml")"
+echo "    component version: ${head_version:-<none>}"
+
+# ---------------------------------------------------------------------------
+# 2. Stage the cover logo
+#
+# index.adoc renders the logo through the `cover-logo` attribute, which defaults
+# to the central `common` component (antora.yml). No such component exists in a
+# single-repo build, so vendor the copy that already ships in the docs-resources
+# submodule -- the same asset the PDF build uses -- into this component's images
+# family and point the attribute at it. Staged, not committed (.gitignore).
+# ---------------------------------------------------------------------------
+logo_src="$repo_root/docs-resources/images/risc-v_logo.svg"
+logo_dest_dir="$repo_root/modules/ROOT/images"
+cover_logo=""
+if [ -f "$logo_src" ]; then
+  mkdir -p "$logo_dest_dir"
+  cp "$logo_src" "$logo_dest_dir/risc-v_logo.svg"
+  cover_logo="risc-v_logo.svg"
+  echo "==> Staged cover logo from docs-resources"
+else
+  echo "==> WARNING: $logo_src not found (submodule not initialized?)."
+  echo "    Falling back to the 'common::' logo, which cannot resolve in a"
+  echo "    single-repo build -- the cover image will be broken. Run:"
+  echo "        git submodule update --init --recursive"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Choose which versions to publish
+#
+# Always publish the checked-out worktree (branches: HEAD), which carries the
+# stamp applied above.
+#
+# Additionally publish any RELEASE TAG that already carries a correctly stamped
+# descriptor, so the site grows a version dropdown across releases. A tag
+# qualifies only if it contains an antora.yml whose `version:` equals the tag
+# itself. Two reasons this is strict:
+#   * Antora aborts the whole build on any ref that has no antora.yml, so tags
+#     predating the Antora migration MUST be filtered out here.
+#   * A tag stamped with some other version (e.g. the template default v0.0.0,
+#     or the previous release, because stamping currently happens on main after
+#     the tag is cut) would publish under a wrong or duplicate version path.
+# Today that means no tag qualifies and the site publishes a single version.
+# Once the release flow stamps antora.yml BEFORE cutting the tag, older releases
+# start appearing here automatically -- no change to this script.
+# ---------------------------------------------------------------------------
+sources=()
+tag_list=()
+while IFS= read -r tag; do
+  [ -n "$tag" ] || continue
+  if ! git cat-file -e "$tag:antora.yml" 2>/dev/null; then
+    echo "    skip $tag (no antora.yml -- predates the Antora layout)"
+    continue
+  fi
+  tag_version="$(git show "$tag:antora.yml" | descriptor_version)"
+  if [ "$tag_version" != "$tag" ]; then
+    echo "    skip $tag (descriptor says '${tag_version:-<none>}', not stamped at tag time)"
+    continue
+  fi
+  if [ "$tag_version" = "$head_version" ]; then
+    echo "    skip $tag (same version as the worktree build)"
+    continue
+  fi
+  tag_list+=("$tag")
+done < <(git tag --list "$tag_glob" --sort=-version:refname)
+
+echo "==> Publishing versions: ${head_version:-HEAD} ${tag_list[*]:-}"
+if [ ${#tag_list[@]} -gt 0 ]; then
+  tags_json="$(printf '%s\n' "${tag_list[@]}" | node -e '
+    const tags = require("fs").readFileSync(0, "utf8").split("\n").filter(Boolean);
+    process.stdout.write(JSON.stringify({ url: ".", tags }));
+  ')"
+  sources+=(--source "$tags_json")
+fi
+sources+=(--source '{"url": ".", "branches": "HEAD"}')
+
+# ---------------------------------------------------------------------------
+# 4. Generate the playbook and build
+# ---------------------------------------------------------------------------
+gen_args=(--in "$repo_root/antora-playbook.yml" --out "$generated_playbook"
+          --output-dir "$output_dir")
+[ -n "$site_url" ] && gen_args+=(--url "$site_url")
+[ -n "$cover_logo" ] && gen_args+=(--cover-logo "$cover_logo")
+
+echo "==> Generating $(basename "$generated_playbook")"
+node "$here/gen-pages-playbook.js" "${gen_args[@]}" "${sources[@]}"
+
+echo "==> Building site into $output_dir"
+antora_bin="$repo_root/node_modules/.bin/antora"
+[ -x "$antora_bin" ] || antora_bin="npx antora"
+$antora_bin --fetch "$generated_playbook"
+
+echo "==> Done: $output_dir"

--- a/scripts/gen-pages-playbook.js
+++ b/scripts/gen-pages-playbook.js
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+'use strict';
+
+// Generate the GitHub Pages playbook by OVERLAYING a few keys onto the local
+// preview playbook (antora-playbook.yml).
+//
+// Why derive instead of committing a second playbook: antora-playbook.yml
+// carries a large `asciidoc.attributes` block that is a hand-maintained MIRROR
+// of the central playbook (github.com/riscv-admin/antora.riscv.org) -- see
+// ANTORA.md design rule #2. A second standalone playbook would duplicate that
+// block, and the two copies would silently drift apart on the next central
+// change. So the Pages build reuses it verbatim and overrides only:
+//
+//   site.url        -- the Pages base URL (project sites live under /<repo>/,
+//                      not at the domain root, and Antora needs the base path
+//                      for the sitemap and any absolute links)
+//   content.sources -- the versions to publish (see build-pages-site.sh)
+//   output.dir      -- separate from the preview output, so a publish never
+//                      clobbers ./build/site
+//   cover-logo      -- resolve the cover logo from THIS component instead of
+//                      the central `common` component, which does not exist in
+//                      a single-repo build (see antora.yml)
+//
+// Usage: gen-pages-playbook.js --out <file> [--url <base>] [--source <json>]...
+// Each --source is a JSON object appended to content.sources, in order.
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+function parseArgs(argv) {
+  const args = { sources: [] };
+  for (let i = 0; i < argv.length; i += 1) {
+    const flag = argv[i];
+    const value = argv[i + 1];
+    if (value === undefined) throw new Error(`missing value for ${flag}`);
+    switch (flag) {
+      case '--in': args.in = value; i += 1; break;
+      case '--out': args.out = value; i += 1; break;
+      case '--url': args.url = value; i += 1; break;
+      case '--output-dir': args.outputDir = value; i += 1; break;
+      case '--cover-logo': args.coverLogo = value; i += 1; break;
+      case '--source': args.sources.push(JSON.parse(value)); i += 1; break;
+      default: throw new Error(`unknown option: ${flag}`);
+    }
+  }
+  if (!args.in) throw new Error('--in is required');
+  if (!args.out) throw new Error('--out is required');
+  if (!args.sources.length) throw new Error('at least one --source is required');
+  return args;
+}
+
+const args = parseArgs(process.argv.slice(2));
+const playbook = yaml.load(fs.readFileSync(args.in, 'utf8'));
+
+playbook.site = playbook.site || {};
+if (args.url) playbook.site.url = args.url;
+
+playbook.content = playbook.content || {};
+playbook.content.sources = args.sources;
+
+if (args.outputDir) {
+  playbook.output = playbook.output || {};
+  playbook.output.dir = args.outputDir;
+}
+
+// Hard-set (no trailing `@`), so it takes precedence over the default in the
+// component descriptor. antora.yml keeps the `common::` value that the central
+// multi-source build needs; only this build swaps in the vendored copy.
+if (args.coverLogo) {
+  playbook.asciidoc = playbook.asciidoc || {};
+  playbook.asciidoc.attributes = playbook.asciidoc.attributes || {};
+  playbook.asciidoc.attributes['cover-logo'] = args.coverLogo;
+}
+
+const banner = [
+  '# GENERATED FILE -- DO NOT EDIT, DO NOT COMMIT.',
+  '# Produced by scripts/gen-pages-playbook.js from ' + path.basename(args.in) + '.',
+  '# Edit that file (or scripts/build-pages-site.sh) instead.',
+  '',
+].join('\n');
+
+fs.writeFileSync(args.out, banner + yaml.dump(playbook, { lineWidth: -1, noRefs: true }));
+process.stdout.write(`wrote ${args.out}\n`);


### PR DESCRIPTION
Adds a per-repo GitHub Pages publish of the Antora HTML site, so a repo seeded from this template produces both the release PDF and a published HTML site.

## ⚠️ Revert the second commit before merging

`ci: TEMPORARY trigger the Pages publish from this branch` adds `push: branches: [publish-to-pages]` so the workflow can be proven end to end before it reaches `main`. Neither real trigger can do that yet — `workflow_dispatch` only appears once the file is on the default branch, and pushing a `v*` tag to test would also fire `build-pdf.yml` and cut a real release of the template. It is isolated in its own commit, so removal is `git revert`.

## ⚠️ This publish is outward-facing

A successful run enables GitHub Pages on `riscv/docs-spec-template` (Pages is currently not enabled) and serves the sample spec publicly at https://riscv.github.io/docs-spec-template/. For a template that is arguably a feature — a live demo of its output — but it is a deliberate choice, not a side effect to discover later. `enablement: true` calls the Pages API with the Actions token; if org policy restricts that, this run is where it surfaces, which is better than in someone's spec repo.

Pages settings are not copied to repos created from a template, so enabling it here does not skip the first-run path in seeded repos.

## What it does

- `.github/workflows/publish-site.yml` — runs on `v*` tags and manual dispatch. `configure-pages` (`enablement: true`) → Kroki → build → `deploy-pages`. No setup needed in a seeded repo. Skips on private repos, where Pages needs Team/Enterprise.
- `scripts/build-pages-site.sh` — the whole build, runnable locally.
- `scripts/gen-pages-playbook.js` — derives the Pages playbook from `antora-playbook.yml`.

This does not replace `docs.riscv.org`, which is assembled centrally and stays canonical.

## Design notes

**The Pages playbook is derived, not committed.** `antora-playbook.yml` carries a hand-maintained mirror of the central playbook's rendering attributes; a second committed copy would drift on the next central change. The generator overrides only `site.url` (project Pages sites live under `/<repo>/`), `content.sources`, `output.dir`, and the cover logo — verified inheriting all 34 attributes and both extensions.

**Cover logo.** `index.adoc` now renders `image::{cover-logo}[]`, defaulting in `antora.yml` to the central `common::` asset. A single-repo build has no `common` component, so the Pages build stages the copy from the `docs-resources` submodule and hard-sets the attribute. The central build is unchanged, and the local preview still emits the exact unresolved-image message that `validate-content-source.yml` exception-lists.

**Version stamping** is applied to the working tree at build time from `release-info.sh` — the same source the PDF uses — and never committed, so the published version matches the PDF even though a tagged commit's `antora.yml` has not been stamped yet. `build-pdf.yml` still owns stamping `main`.

## Known limitation: one version, not a dropdown

The build scans release tags and publishes any whose descriptor version equals the tag. **No tag qualifies today**, so the site publishes a single version. Two reasons, neither fixable here:

1. Tags are pushed *before* `build-pdf.yml` stamps `main`, so a tag never contains its own version (`v4.0.4`'s descriptor says `v0.0.0`).
2. Antora aborts the entire build on any ref lacking `antora.yml`, so pre-Antora tags must be filtered regardless.

If the release flow is ever changed to stamp and commit before cutting the tag, past releases appear in a version dropdown automatically, with no change to these scripts. That touches the release automation, so it is deliberately out of scope here.

## Verification

- Clean end-to-end build (7 pages); `site.url` correct in the sitemap, canonical links, and root redirect; cover logo resolving to the vendored copy.
- Stamped path (`VERSION=v0.9`) verified, then reverted — that was test input.
- Existing `validate-content-source.yml` gate still passes unchanged.
- Cold start verified against a tagless clone (what a seeded repo looks like): `release-info.sh` falls back to `v0.0-<sha>-<date>` and the stamp succeeds, so the first dispatch in a new repo works, with a dev-style version segment in the path until the first real tag.
- All pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)