### PR TITLE
docs: migration guide, changelog, and README updates for the Pages publish

### DIFF
--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -29,9 +29,10 @@ on:
   workflow_dispatch:
 
 # contents: read      -- checkout only; this workflow never writes to the repo.
-#                        In particular it does NOT commit the version stamp: the
+#                        In particular it does NOT persist the version stamp: the
 #                        stamp is applied to the working tree for the build and
-#                        thrown away (build-pdf.yml owns committing it to main).
+#                        thrown away. Getting it onto main stays build-pdf.yml's
+#                        job, which opens a review PR for it.
 # pages/id-token      -- required by actions/deploy-pages (OIDC deployment).
 permissions:
   contents: read

--- a/ANTORA.md
+++ b/ANTORA.md
@@ -164,8 +164,8 @@ from.
 The version stamp is applied to the **working tree** at build time from
 `scripts/release-info.sh` — the same source the PDF uses — so the published
 version matches the PDF even though the tagged commit's committed `antora.yml`
-has not been stamped yet. Nothing is committed back; `build-pdf.yml` still owns
-stamping `main`.
+has not been stamped yet. Nothing is committed back; getting the stamp onto
+`main` stays `build-pdf.yml`'s job, which opens a review PR for it.
 
 The build also scans release tags and publishes any that carry a correctly
 stamped descriptor, which is what would give the site a multi-version dropdown. A

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **_NOTE:_** PROJECTS BUILT USING THE TEMPLATE SHOULD UPDATE THE BELOW SECTIONS AS-NEEDED.
 
 ## [Unreleased]
+- Publish the Antora HTML site to the repository's own GitHub Pages site on each
+  `v*` release tag, alongside the release PDF (`publish-site.yml`,
+  `scripts/build-pages-site.sh`). Requires a one-time *Settings > Pages >
+  Source: GitHub Actions* by a repository admin. Does not replace the central
+  docs.riscv.org site.
 
 ## [4.0.0] - 2004-01-27
 - Workflow improvements

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -15,6 +15,9 @@ source tree, and a spec author needs both:
 2. **The Antora HTML site.** Chapter content is consumed as a *content source*
    by the RISC-V central playbook and published on antora.riscv.org. The ARC
    Author Guide requires the site version to match the PDF version **exactly**.
+   Optionally, the same content can also be published to your own repo's GitHub
+   Pages site (Step 13a) — a standalone copy, not a replacement for the central
+   site.
 
 Parts A and C below are the PDF; Part B is the site. **Do not stop after Part
 A** — a repo that does gets a compliant PDF and no site.
@@ -41,6 +44,9 @@ is the sequence of actions; ANTORA.md is the rationale.
 > `antora.yml`, `antora-playbook.yml`, `modules/ROOT/nav.adoc`, `package.json`,
 > `docker-compose.yml`, `scripts/stamp-antora-version.sh`, and
 > `.github/workflows/validate-content-source.yml` in addition to the PDF files.
+> Adopting the optional GitHub Pages publish (Step 13a) adds
+> `.github/workflows/publish-site.yml`, `scripts/build-pages-site.sh`, and
+> `scripts/gen-pages-playbook.js`.
 
 ---
 
@@ -439,6 +445,62 @@ file.
       xrefs into other specs). These resolve only in the central multi-source
       build and are *expected* to be unresolved here.
 
+## Step 13a — Publish to your own GitHub Pages site (optional)
+
+Steps 1–13 give you the ARC PDF and a component the central playbook can
+consume. This step additionally publishes a **standalone copy** of the same
+content to your repo's own GitHub Pages site on every release. It does not
+replace antora.riscv.org, which stays canonical for RISC-V specs — but it is the
+primary HTML output for a spec that is not part of the central library, and a
+useful full-fidelity preview for one that is. Skip this step freely; nothing
+else depends on it.
+
+- [ ] Copy `.github/workflows/publish-site.yml`, `scripts/build-pages-site.sh`,
+      and `scripts/gen-pages-playbook.js`. The workflow runs on `v*` tags and on
+      `workflow_dispatch`; the build lives in the script so it is reproducible
+      locally.
+- [ ] Render the cover logo through an attribute, so the page works in both
+      builds. In `antora.yml`:
+      ```yaml
+          cover-logo: common::risc-v_logo.svg
+      ```
+      and in `modules/ROOT/pages/index.adoc` use `image::{cover-logo}[...]`
+      instead of a literal `common::risc-v_logo.svg`. The central build keeps
+      using the shared asset; the Pages build overrides the attribute with a
+      copy vendored from the `docs-resources` submodule, because a single-repo
+      build has no `common` component.
+- [ ] Add the generated artifacts to `.gitignore`:
+      ```gitignore
+      /antora-pages-playbook.yml
+      /modules/ROOT/images/risc-v_logo.svg
+      ```
+- [ ] **Have a repository admin enable Pages once**: *Settings → Pages → Build
+      and deployment → Source: GitHub Actions*. The workflow asks for this
+      automatically (`enablement: true`), but the RISC-V organization restricts
+      Pages site creation, so the workflow's token is refused with
+      `Resource not accessible by integration`. Equivalent API call:
+      ```bash
+      gh api -X POST repos/<org>/<repo>/pages -f build_type=workflow
+      ```
+      Pages also needs a public repo unless your org is on Team/Enterprise; the
+      job skips itself on private repos rather than failing your release.
+- [ ] Verify locally before pushing (needs Kroki, as in Step 10):
+      ```bash
+      NO_STAMP=1 ./scripts/build-pages-site.sh   # -> build/pages-site/
+      ```
+- [ ] Verify in CI: run the workflow manually and confirm the site appears at
+      `https://<org>.github.io/<repo>/`. A repo with no release tags yet
+      publishes under `/<component>/dev/` rather than a
+      `v<latest>-<hash>-<date>` path — that is deliberate, and the exact commit
+      is still shown on the cover page.
+
+> **One version, not a dropdown.** The build publishes the checked-out ref, plus
+> any release tag whose `antora.yml` names that same tag. Under the standard
+> release flow the tag is cut *before* the stamp PR from Step 12 merges, so no
+> tag carries its own version and exactly one version is published. Tags that
+> predate your Antora migration are skipped with a reason rather than aborting
+> the build — Antora fails hard on any ref lacking `antora.yml`.
+
 ---
 
 # Part C — Release and submit
@@ -465,6 +527,10 @@ When you're ready to advance to the next milestone:
       make stamp-antora VERSION=vX.Y
       git add antora.yml && git commit -m "Stamp site version vX.Y"
       ```
+- [ ] If you adopted Step 13a, confirm your own Pages site published at
+      `https://<org>.github.io/<repo>/<component>/vX.Y/`. It is stamped
+      independently of the Step 12 PR, so it is correct as soon as the tag
+      build finishes — it does not wait for that PR to merge.
 - [ ] If you changed `nav.adoc` this cycle, re-check the central
       `numbering_rules` entry (Step 11) — including its `branches:`/`tags:`.
 - [ ] Use the **GitHub Release URL** (not a branch or commit URL) in the ARC

--- a/README.adoc
+++ b/README.adoc
@@ -48,10 +48,13 @@ When instantiating a new repository from this template, perform these one-time s
 
 The following directories are used to organize the contents of this repo:
 
-* `dependencies/`: software dependencies needed to build the specification
+* `modules/`: the specification content, in Antora layout — chapter pages in `modules/ROOT/pages/`, site navigation in `modules/ROOT/nav.adoc`, and supporting files such as the BibTeX database in `modules/ROOT/resources/`. **This is where you write.**
+* `src/`: the PDF assembler (`spec-sample.adoc`). It is a thin document that `include::`s the same chapter pages from `modules/ROOT/` to produce the ARC submission PDF, so one source tree feeds both the PDF and the HTML site — see link:ANTORA.md[ANTORA.md].
 * `docs-resources/`: resources for all specifications sourced from link:.gitmodules[git submodule]
-* `src/`: source files for the specification
-* `build/`: default directory where the build artifacts are generated
+* `scripts/`: versioning and publishing helpers. `release-info.sh` is the single source of version and phase truth for both artifacts; the others stamp the site version, update `SPEC_STATE.md`, and build the GitHub Pages site.
+* `tests/`: shell tests for those helper scripts
+* `dependencies/`: software dependencies needed to build the specification
+* `build/`: default directory where the build artifacts are generated — the PDF, plus the HTML site under `build/site/` (local preview) or `build/pages-site/` (GitHub Pages build)
 
 === Prerequisites
 


### PR DESCRIPTION
Follow-up to #127. These two commits were pushed to `publish-to-pages` after that PR had already been merged, so they never landed.

### `docs: cover the Pages publish in the migration guide and changelog`

**MIGRATION.md** is the actionable checklist a downstream repo follows, and the Pages publish was missing from it entirely — #127 documented the feature in `ANTORA.md` and `README.adoc` only. Adds **Step 13a** (optional, after the CI content-source gate): the three files to copy, the `cover-logo` indirection in `antora.yml` and `index.adoc`, the `.gitignore` entries, the one-time admin step to enable Pages, and local plus CI verification. Also updates the two places that enumerate scope, and adds a line to Step 14.

Numbered `13a` rather than renumbering Steps 14–15, which are cross-referenced from Step 12.

**Corrects an inaccuracy currently on `main`.** `publish-site.yml` and `ANTORA.md` both say `build-pdf.yml` commits the version stamp to `main`. It does not — it opens a review PR (`peter-evans/create-pull-request`, branch `gitbot/stamp-site-<version>`), exactly as MIGRATION.md already described. The substantive point is unchanged and slightly stronger: the stamp reaches `main` only when a human merges that PR, always after the tag exists, so a release tag still never carries its own version and the single-version publishing behaviour holds.

**CHANGELOG.md** gets an `[Unreleased]` entry.

### `docs: document the full directory structure in the README`

The README's *Directory Structure* list still described the pre-Antora layout: it called `src/` "source files for the specification" and omitted `modules/` altogether, despite chapter content having moved to `modules/ROOT/pages/` during the migration — so it pointed new authors at the wrong directory. `scripts/` and `tests/` were missing too.

Adds `modules/`, `scripts/`, and `tests/`, and rewrites the `src/` and `build/` entries to describe what they actually hold.

### Verification

Documentation only — no workflow or script behaviour changes. `README.adoc` renders clean at `--failure-level=WARN`; all pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)