### PR TITLE
fix(build): stop stamping the date twice in local ARC PDF names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,12 @@ build-docs: check-docs-resources $(DOCS_PDF) $(DOCS_HTML)
 # (local or CI) emits a uniquely identifiable artifact.
 ARC_PDF = $(1)-v$(VERSION_NUM)-$(DATE_STAMP).pdf
 
+# ...but only a build off a clean vX.YY -- a tag, or an explicit VERSION= as CI
+# passes -- is actually SUBMITTABLE. An untagged build resolves VERSION to
+# <latest>-<sha> (release-info.sh), so its filename carries the sha and is a dev
+# artifact. Report that honestly rather than asserting compliance it lacks.
+ARC_EXACT := $(if $(findstring -,$(VERSION)),,yes)
+
 vpath %.adoc $(SRC_DIR)
 
 # AsciiDoctor writes the ARC name itself (-o is resolved relative to -D), rather
@@ -123,7 +129,13 @@ vpath %.adoc $(SRC_DIR)
 %.pdf: %.adoc
 	$(DOCKER_CMD) $(DOCKER_QUOTE) $(ASCIIDOCTOR_PDF) $(OPTIONS) $(REQUIRES) -o $(call ARC_PDF,$*) $< $(DOCKER_QUOTE)
 	@test -f build/$(call ARC_PDF,$*) || { echo "ERROR: build/$(call ARC_PDF,$*) was not produced" >&2; exit 1; }
-	@echo "ARC submission PDF: build/$(call ARC_PDF,$*)"
+	@if [ -n "$(ARC_EXACT)" ]; then \
+		echo "ARC submission PDF: build/$(call ARC_PDF,$*)"; \
+	else \
+		echo "Development PDF: build/$(call ARC_PDF,$*)"; \
+		echo "  Built from an untagged commit ($(VERSION)) -- NOT an ARC submission artifact."; \
+		echo "  Build from a v* tag, or run 'make VERSION=vX.YY', to produce one."; \
+	fi
 
 %.html: %.adoc
 	$(DOCKER_CMD) $(DOCKER_QUOTE) $(ASCIIDOCTOR_HTML) $(OPTIONS) $(REQUIRES) $< $(DOCKER_QUOTE)

--- a/scripts/release-info.sh
+++ b/scripts/release-info.sh
@@ -227,11 +227,16 @@ get_version() {
       return 0
     fi
 
-    local latest short_sha build_date
+    # Untagged: <latest tag>-<sha>, with NO date folded in. The build date
+    # already reaches every artifact independently -- the Makefile passes it as
+    # revdate and appends DATE_STAMP to the ARC filename -- so embedding it here
+    # too stamped local PDFs with the date twice (spec-v0.6-abc-20260812-20260812
+    # .pdf), which is not ARC-compliant. The sha alone keeps the build uniquely
+    # identifiable and marks it as not built from a tag.
+    local latest short_sha
     latest="$(latest_tag)"
     short_sha="$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")"
-    build_date="$(date +%Y%m%d)"
-    echo "${latest}-${short_sha}-${build_date}"
+    echo "${latest}-${short_sha}"
     return 0
   fi
 

--- a/tests/release-info-test.sh
+++ b/tests/release-info-test.sh
@@ -110,9 +110,35 @@ ok "display v1.0"  Ratified    "$("$RI" display v1.0)"
 rc "publication is not a valid phase floor"  2  "$RI" phase-floor-version publication
 
 # --- interim build non-tagged versions ---------------------------------------
+ok "normalize v0.60-a1b2c3d" "v0.6-a1b2c3d" "$("$RI" normalize v0.60-a1b2c3d)"
+rc "v0.6-a1b2c3d not a milestone" 1 "$RI" is-milestone v0.6-a1b2c3d
+ok "phase v0.6-a1b2c3d" development-complete "$("$RI" phase v0.6-a1b2c3d)"
+# Suffix handling stays generic, incl. the legacy date-bearing dev form.
 ok "normalize v0.60-a1b2c3d-20260730" "v0.6-a1b2c3d-20260730" "$("$RI" normalize v0.60-a1b2c3d-20260730)"
-rc "v0.6-a1b2c3d-20260730 not a milestone" 1 "$RI" is-milestone v0.6-a1b2c3d-20260730
 ok "phase v0.6-a1b2c3d-20260730" development-complete "$("$RI" phase v0.6-a1b2c3d-20260730)"
+
+# --- dev version carries NO date (#131) --------------------------------------
+# The Makefile appends DATE_STAMP to build the ARC filename
+# <short>-v<version>-<YYYYMMDD>.pdf. A dev version that embedded its own build
+# date therefore stamped the date TWICE on every local build. Assert the emitted
+# shape is <latest>-<sha> so the concatenation stays ARC-shaped.
+devrepo="$(mktemp -d)"
+(
+  cd "$devrepo" || exit 1
+  git init -q .
+  git -c user.email=t@example.com -c user.name=t commit -q --allow-empty -m init
+  git tag v0.6
+  git -c user.email=t@example.com -c user.name=t commit -q --allow-empty -m untagged
+) >/dev/null 2>&1
+ri_clean() { (cd "$devrepo" && env -u VERSION -u RELEASE_VERSION -u GITHUB_REF_NAME -u GITHUB_REF "$RI" "$@"); }
+dev_sha="$(cd "$devrepo" && git rev-parse --short HEAD)"
+dev_version="$(ri_clean version)"
+ok "untagged build version is <latest>-<sha>"  "v0.6-$dev_sha"  "$dev_version"
+ok "untagged build version has no date stamp"  ""  "$(printf '%s' "$dev_version" | grep -oE '[0-9]{8}' || true)"
+ok "untagged build phase still resolves"  development-complete  "$(ri_clean phase "$dev_version")"
+(cd "$devrepo" && git checkout -q v0.6)
+ok "tagged build version is the bare tag"  v0.6  "$(ri_clean version)"
+rm -rf "$devrepo"
 
 # --- 3-digit input is rejected ----------------------------------------------
 rc "normalize rejects v0.6.0"  2  "$RI" normalize v0.6.0


### PR DESCRIPTION
Fixes #131.

## Problem

`make` on an untagged commit produced a PDF whose filename carried the build date twice — `spec-sample-v0.81-ead4323-20260812-20260812.pdf` — while the recipe printed `ARC submission PDF:` with that name.

`VERSION` defaults to `scripts/release-info.sh version`, whose untagged branch returned `<latest>-<sha>-<date>`. `ARC_PDF` then appended `DATE_STAMP` to it.

CI was never affected: `build-pdf.yml` exports an explicit `VERSION` before calling `make`, so it always took the clean path. That is why the local default was the only broken one.

## Fix

The date in the dev version string was always redundant — the Makefile already passes `DATE` as `revdate` and appends `DATE_STAMP` to the filename, so no artifact relied on it. Dropping it makes the concatenation ARC-shaped again while the sha still keeps the build identifiable.

Normalizing the filename to the bare `vX.YY` instead was the other option the issue raised, but that makes an untagged build emit *exactly* the name a real tagged release build emits. A silent collision in a submission pipeline is worse than a loud wrong name.

The second half of the issue — the log asserting compliance the artifact does not have — is handled by `ARC_EXACT`: only a build off a clean `vX.YY` (a tag, or an explicit `VERSION=`) is submittable, so an untagged build now reports itself as a development PDF and says how to produce a submission one.

| | before | after |
|---|---|---|
| `make` (untagged) | `spec-sample-v0.01-3c1b0ff-20260812-20260812.pdf`, logged as "ARC submission PDF" | `spec-sample-v0.01-3c1b0ff-20260812.pdf`, logged as "Development PDF … NOT an ARC submission artifact" |
| `make VERSION=v0.82` (CI) | `spec-sample-v0.82-20260812.pdf` | unchanged |

## Tests

`tests/release-info-test.sh` builds a throwaway repo (tag `v0.6`, then an untagged commit) and asserts the emitted version is exactly `v0.6-<sha>`, contains no 8-digit date, still resolves its phase, and collapses to the bare tag on a tagged HEAD. The legacy date-bearing string is kept as an input case so suffix handling stays generic.

64 passed, 0 failed.

## Not covered here

- A real container build was not run — the change is filename-level and `make -n` shows the exact command, but the `riscv-docs-base-container-image` path is unexercised by this branch.
- `scripts/build-pages-site.sh:67-69` documents the dev version as `vX.YY-<sha>-<date>` ("22 chars") to justify the `dev` label substitution. Behavior is unaffected (the `*-*` match still fires), but the comment is stale as of this change. Happy to fold the two-line correction in here if reviewers prefer.
- `make stamp-antora` on an untagged commit still stamps the full describe string into `antora.yml`, since `release-info.sh normalize` preserves the suffix. Same root cause, but it is documented as release-time-only, so it is left out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)