### PR TITLE
ci: keep the rendered HTML in the PR build artifact

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -125,12 +125,26 @@ jobs:
           echo "Building ${VERSION} (${DATE})"
           make
 
-      # Upload the built PDF files as a single artifact
+      # Upload the built documents as a single artifact.
+      #
+      # The HTML is rendered on every run whether or not we keep it -- build-docs
+      # depends on $(DOCS_HTML) as well as $(DOCS_PDF) -- so retaining it costs no
+      # extra build time, and reviewers get the rendered document instead of only
+      # the PDF. It travels as one file: the spec sets :data-uri:, so images and
+      # the stylesheet are inlined and nothing sidecar has to ship with it.
+      #
+      # `*` does not cross directory separators, so this cannot sweep up an Antora
+      # build/site/ or build/pages-site/ tree if one ever lands in this job.
+      #
+      # Release assets stay PDF-only on purpose (see the steps below): the ARC
+      # submission artifact is the PDF, and the published HTML is the Antora site.
       - name: Upload Build Artifacts
         uses: actions/upload-artifact@v6
         with:
           name: Build Artifacts
-          path: ${{ github.workspace }}/build/*.pdf
+          path: |
+            ${{ github.workspace }}/build/*.pdf
+            ${{ github.workspace }}/build/*.html
           retention-days: 30
 
       # Create official release for version tag pushes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **_NOTE:_** PROJECTS BUILT USING THE TEMPLATE SHOULD UPDATE THE BELOW SECTIONS AS-NEEDED.
 
 ## [Unreleased]
+- Retain the rendered HTML in the PR build artifact (`build-pdf.yml`). The build
+  already produced it on every run and then discarded it; the upload glob now
+  covers `build/*.html` alongside `build/*.pdf`. Release assets remain PDF-only.
 - Publish the Antora HTML site to the repository's own GitHub Pages site on each
   `v*` release tag, alongside the release PDF (`publish-site.yml`,
   `scripts/build-pages-site.sh`). Requires a one-time *Settings > Pages >

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -188,8 +188,24 @@ Should show `-o spec-sample-v0.8-20260612.pdf` on the `asciidoctor-pdf` line.
           echo "Building ${VERSION} (${DATE})"
           make
       ```
-- [ ] **No change needed** to upload globs — `path: build/*.pdf` and
-      `files: build/*.pdf` will pick up the ARC-named PDF automatically.
+- [ ] **No change needed** to the release globs — `files: build/*.pdf` picks up
+      the ARC-named PDF automatically. Release assets stay PDF-only: the ARC
+      submission artifact is the PDF, and the published HTML is the Antora site.
+- [ ] **Widen the artifact upload** to keep the HTML the build already produces:
+      ```yaml
+      - name: Upload Build Artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: Build Artifacts
+          path: |
+            ${{ github.workspace }}/build/*.pdf
+            ${{ github.workspace }}/build/*.html
+          retention-days: 30
+      ```
+      `make` renders both formats on every run (`build-docs` depends on
+      `$(DOCS_HTML)`), so this costs no build time and gives reviewers the
+      rendered document on each PR. `:data-uri:` inlines images and the
+      stylesheet, so the `.html` is self-contained and needs no sidecar files.
 - [ ] This workflow also carries the site version stamp once you do Part B —
       see Step 12. Sync the whole upstream file if you can; it resolves
       `VERSION`/`DATE` once and shares them between the PDF build and the stamp
@@ -561,7 +577,8 @@ When you're ready to advance to the next milestone:
   name ARC expects.
 - **GitHub Actions caching:** if you cache `build/` between runs, clear the
   cache once so a stale PDF from an earlier version doesn't ghost the current
-  output — the release step globs `build/*.pdf` and would attach both.
+  output — the release step globs `build/*.pdf` and would attach both (the
+  artifact upload globs `*.html` too, with the same exposure).
 - **Don't rewrite tags.** Push a new monotonically-greater tag if you need to
   reissue.
 - **`:toc: macro` requires explicit placement.** If you switch from


### PR DESCRIPTION
Closes #132.

## The problem

`make` renders **both** formats on every run — `build-docs` depends on `$(DOCS_HTML)` as well as `$(DOCS_PDF)`, and the shared `-D build` option puts both in `build/`. But the upload step globbed only `*.pdf`, so every PR paid the full HTML render cost and then destroyed the file when the runner was torn down.

## The change

The artifact upload now globs `build/*.html` alongside `build/*.pdf`.

Two things make this safe rather than a half-broken preview:

- **The HTML is self-contained.** `src/spec-sample.adoc` sets `:data-uri:`, so images and the default stylesheet are inlined — verified against a local build: all four images are base64 data URIs, and the only external references are the Google Fonts and Font Awesome CDN links, which degrade gracefully offline. No sidecar `images/` directory has to ship with it.
- **The glob cannot over-collect.** `*` does not cross directory separators, so an Antora `build/site/` or `build/pages-site/` tree landing in this job later would not be swept in.

## Deliberately not changed

**Release assets stay PDF-only.** The four `softprops/action-gh-release` steps still glob `build/*.pdf`. The ARC submission artifact is the PDF, and the published HTML story is the Antora site (`publish-site.yml`) — attaching a second HTML asset to every release would muddy both. This issue is about PR-time review artifacts.

**The HTML filename stays unstamped.** The zip contains `spec-sample-v0.62-20260812.pdf` next to a bare `spec-sample.html`, which is asymmetric. But the ARC naming rule applies to the submission PDF, and #131 just consolidated that date-stamp logic in one place; growing a second copy of it for a file no downstream consumer names isn't worth it. If it turns out reviewers need to tell apart HTMLs from two runs, that's one `-o` line in the `%.html` rule as a follow-up.

## Scope note

`upload-artifact` always zips, so reviewers download and unzip rather than clicking through to a rendered page. That's real value for catching render regressions and for offline reading, but it is not a preview — #133 covers PR-time preview of the Antora site.

## Also updated

- `MIGRATION.md` Step 3 — the checklist previously told migrating repos "no change needed" to the upload globs. It now splits the guidance: release globs unchanged, artifact upload widened, with the reasoning. The `build/` caching caveat further down now notes the `*.html` exposure too.
- `CHANGELOG.md` — Unreleased entry.

## Verification

- `pre-commit run --files .github/workflows/build-pdf.yml MIGRATION.md CHANGELOG.md` — passes (`check-yaml`, `yamlfmt`, whitespace hooks).
- Parsed the workflow with PyYAML and confirmed the step resolves to the two-line `path` block scalar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)