### PR TITLE
ci: keep the PR gate's rendered site as a preview artifact

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -127,11 +127,31 @@ jobs:
 
       # Upload the built PDF files as a single artifact
       - name: Upload Build Artifacts
+        id: upload
         uses: actions/upload-artifact@v6
         with:
           name: Build Artifacts
           path: ${{ github.workspace }}/build/*.pdf
           retention-days: 30
+
+      # Put a direct link in the run summary, so reaching the build output is one
+      # click from the Checks tab rather than a hunt down the summary page. Same
+      # reasoning as validate-content-source.yml: needs no permissions and works
+      # on fork PRs, unlike a PR comment.
+      - name: Link the build artifacts in the run summary
+        if: steps.upload.outputs.artifact-url != ''
+        env:
+          ARTIFACT_URL: ${{ steps.upload.outputs.artifact-url }}
+        run: |
+          set -euo pipefail
+          {
+            echo "### Built document"
+            echo
+            echo "[Download the build artifacts]($ARTIFACT_URL) — \`${VERSION}\` (${DATE})."
+            echo
+            echo "- Downloading requires being signed in to GitHub (an Actions limitation)."
+            echo "- Retained for 30 days."
+          } >> "$GITHUB_STEP_SUMMARY"
 
       # Create official release for version tag pushes
       - name: Create Release (Tag Push, Official)

--- a/.github/workflows/validate-content-source.yml
+++ b/.github/workflows/validate-content-source.yml
@@ -17,6 +17,14 @@ name: Validate Antora content source
 #
 # The release-time version stamp (make stamp-antora -> antora.yml) is NOT part of
 # this gate; it runs from build-pdf.yml on release. See ANTORA.md Phase 4/6.
+#
+# The gate's build output is also KEPT, as a downloadable artifact, so reviewers
+# can see a content change rendered instead of reading the AsciiDoc diff. The site
+# was already being built here on every PR and thrown away; retaining it costs no
+# build time. This is a HEAD-only preview -- no version selector, no release
+# history -- and it is not a deployment: see the issue trail on why a real per-PR
+# preview host is out of scope for this template (the RISC-V org refuses Pages
+# site creation to the workflow token, and fork PRs cannot hold deploy secrets).
 
 on:
   pull_request:
@@ -45,10 +53,13 @@ jobs:
           - 9870:8000
 
     steps:
+      # submodules -- docs-resources supplies the cover logo staged below. The
+      # gate itself does not need it; the preview artifact does.
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          submodules: recursive
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -76,10 +87,52 @@ jobs:
           echo "::error::Kroki did not become healthy within 60s"
           exit 1
 
-      - name: Build component (isolated)
+      # antora.yml sets `cover-logo: common::risc-v_logo.svg` -- a shared asset
+      # from the central `common` component, which does not exist in a
+      # single-component build, so index.adoc (the start page) renders a broken
+      # image. Tolerable when this job was only a pass/fail gate; not tolerable
+      # now that its output is published as a preview, because index.adoc is the
+      # FIRST page a reviewer opens. Vendor the SVG and hard-set the attribute,
+      # exactly as scripts/build-pages-site.sh does for the Pages build.
+      # modules/ROOT/images/risc-v_logo.svg is gitignored; this only ever touches
+      # the runner's worktree.
+      - name: Stage cover logo
+        id: cover
         run: |
+          set -euo pipefail
+          src=docs-resources/images/risc-v_logo.svg
+          if [ -f "$src" ]; then
+            mkdir -p modules/ROOT/images
+            cp "$src" modules/ROOT/images/risc-v_logo.svg
+            echo "cover_logo=risc-v_logo.svg" >> "$GITHUB_OUTPUT"
+            echo "Staged cover logo from docs-resources."
+          else
+            echo "::warning::$src not found (submodule not initialized?) -- the"
+            echo "::warning::preview cover image will be unresolved."
+            echo "cover_logo=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build component (isolated)
+        env:
+          COVER_LOGO: ${{ steps.cover.outputs.cover_logo }}
+        run: |
+          # Hard-set (playbook-level) so it overrides the antora.yml default.
+          # Omitted entirely if staging failed, leaving the pre-existing
+          # unresolved-`common::` behaviour that the exception below covers.
+          attrs=()
+          if [ -n "$COVER_LOGO" ]; then
+            attrs+=(--attribute "cover-logo=$COVER_LOGO")
+          fi
+
+          # Run the pinned local binary rather than `npx antora`, matching
+          # scripts/build-pages-site.sh. npx routes argv through npm's own
+          # option parser, which claims bare `key=value` arguments -- it warns
+          # `"cover-logo=..." is being parsed as a normal command line argument`
+          # -- so the attribute above is safer passed straight to the CLI.
+          antora_bin=./node_modules/.bin/antora
+
           set +e
-          npx antora --fetch --log-format=json antora-playbook.yml 2>&1 | tee antora-build.log
+          "$antora_bin" --fetch --log-format=json "${attrs[@]}" antora-playbook.yml 2>&1 | tee antora-build.log
           status=${PIPESTATUS[0]}
           set -e
 
@@ -91,6 +144,12 @@ jobs:
           # Antora logs unresolved xrefs/includes/images at error level without
           # failing the build. Treat those as failures -- EXCEPT cross-component
           # references that only resolve in the central multi-source build.
+          #
+          # The cover-logo exception is now the FALLBACK path only: with the logo
+          # staged above the reference resolves and this filter matches nothing,
+          # so the gate actually validates the image macro (it previously could
+          # not -- see modules/ROOT/pages/index.adoc). It stays so an unavailable
+          # submodule degrades to a warning instead of a red gate.
           unexpected="$(grep -E '"level":"(error|fatal)"' antora-build.log \
             | grep -v 'common::risc-v_logo.svg' || true)"
           if [ -n "$unexpected" ]; then
@@ -99,3 +158,37 @@ jobs:
             exit 1
           fi
           echo "Component builds clean (ignoring expected cross-component refs)."
+
+      # The site the gate just built, kept instead of discarded (~4 MB, ~70
+      # files). Uploaded only on a clean gate: a site built from a tree that
+      # failed validation would misrepresent the change.
+      - name: Upload rendered site
+        id: upload
+        uses: actions/upload-artifact@v6
+        with:
+          name: Rendered site (Antora)
+          path: build/site
+          retention-days: 14
+
+      # Put a direct link in the run summary. `artifact-url` is an output of
+      # upload-artifact -- GitHub documents it precisely for this. This is the
+      # cheap half of discoverability: it needs no permissions and works on fork
+      # PRs, where the pull_request GITHUB_TOKEN is read-only and a step here
+      # could not post a PR comment. A comment in the PR conversation needs a
+      # separate workflow_run-triggered workflow; that is deliberately not in
+      # this change.
+      - name: Link the rendered site in the run summary
+        if: steps.upload.outputs.artifact-url != ''
+        env:
+          ARTIFACT_URL: ${{ steps.upload.outputs.artifact-url }}
+        run: |
+          set -euo pipefail
+          {
+            echo "### Rendered site (preview)"
+            echo
+            echo "[Download the rendered Antora site]($ARTIFACT_URL) — unzip, open \`index.html\`."
+            echo
+            echo "- Preview of this branch's HEAD only: no version selector, no release history."
+            echo "- Downloading requires being signed in to GitHub (an Actions limitation)."
+            echo "- Cross-component references into other specs still resolve only on the central site."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/ANTORA.md
+++ b/ANTORA.md
@@ -131,8 +131,15 @@ the shared asset the central build uses. A single-repo build has no `common`
 component, so the Pages build stages the copy from the `docs-resources` submodule
 into `modules/ROOT/images/` (gitignored) and hard-sets the attribute to it. The
 central build is unaffected, and the local-preview behaviour is unchanged — a
-bare `npm run preview` still logs the one expected unresolved `common::` image
-that `validate-content-source.yml` exception-lists.
+bare `npm run preview` still logs the one expected unresolved `common::` image.
+
+`validate-content-source.yml` stages the logo the same way, for a different
+reason: it publishes its render as a PR preview artifact, and `index.adoc` is the
+start page, so an unresolved cover would be the first thing a reviewer sees. A
+side effect is that the gate now actually *validates* the image macro, which it
+could not while it was merely exception-listing the error. The exception stays,
+but only covers the degraded path where the submodule is unavailable — there it
+keeps a missing submodule a warning rather than a red gate.
 
 ### Versions, and why only one is published today
 
@@ -336,9 +343,21 @@ unnumbered back matter).
   `antora-playbook.yml` (npm ci → Kroki service on :9870 → `npx antora`), as a
   gate so broken AsciiDoc / unresolved intra-component xrefs/includes / extension
   errors fail here instead of stalling the shared central build. It does NOT
-  deploy. Cross-component refs (`common::risc-v_logo.svg`, xrefs into other specs)
-  resolve only centrally, so they are exception-listed. Verified: clean tree
-  passes; an injected broken xref fails the gate.
+  deploy. Cross-component refs (xrefs into other specs) resolve only centrally,
+  so they are exception-listed. Verified: clean tree passes; an injected broken
+  xref fails the gate.
+  * **PR preview artifact.** The gate's render is uploaded as *Rendered site
+    (Antora)* (~4 MB, 14-day retention) instead of being discarded, so a reviewer
+    can see a content change rendered rather than reading the AsciiDoc diff — the
+    build was already happening on every PR, so this costs no build time. The
+    cover logo is staged first (see "The cover logo") so the start page is not
+    broken. Both this job and `build-pdf.yml` write a direct artifact link into
+    `$GITHUB_STEP_SUMMARY` via `upload-artifact`'s `artifact-url` output; that
+    needs no permissions and works on fork PRs, where the `pull_request` token is
+    read-only. It is a HEAD-only preview, not a deployment: a real per-PR preview
+    host was rejected because the RISC-V org refuses Pages site creation to the
+    workflow token (see `publish-site.yml`) and fork PRs cannot hold deploy
+    secrets. Artifact download still requires a signed-in GitHub account.
   * **Version-stamp automation (Phase 4 lockstep, now wired).** `build-pdf.yml`
     resolves `VERSION`/`DATE` once (shared by the PDF build and the stamp, so no
     date drift) and a `stamp-site-version` job stamps the matching `antora.yml`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **_NOTE:_** PROJECTS BUILT USING THE TEMPLATE SHOULD UPDATE THE BELOW SECTIONS AS-NEEDED.
 
 ## [Unreleased]
+- Keep the Antora site that the PR gate already builds, as a *Rendered site
+  (Antora)* artifact, so reviewers can see a content change rendered
+  (`validate-content-source.yml`). The cover logo is now staged from
+  `docs-resources` for that build, so the start page renders standalone — which
+  also means the gate validates the cover image macro instead of exception-listing
+  it. Both build workflows now write a direct artifact link into the run summary.
 - Publish the Antora HTML site to the repository's own GitHub Pages site on each
   `v*` release tag, alongside the release PDF (`publish-site.yml`,
   `scripts/build-pages-site.sh`). Requires a one-time *Settings > Pages >

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -441,9 +441,31 @@ file.
       AsciiDoc, unresolved intra-component xrefs/includes, and extension errors
       fail in your repo instead of stalling the shared central library build. It
       does **not** build or deploy the real site.
-- [ ] Exception-list cross-component references (`common::risc-v_logo.svg`,
-      xrefs into other specs). These resolve only in the central multi-source
-      build and are *expected* to be unresolved here.
+- [ ] Exception-list cross-component references (xrefs into other specs). These
+      resolve only in the central multi-source build and are *expected* to be
+      unresolved here.
+- [ ] Keep the gate's render as a PR preview artifact — the site is built on
+      every PR either way, so retaining it costs no build time and lets
+      reviewers see a content change rendered:
+      ```yaml
+      - name: Upload rendered site
+        id: upload
+        uses: actions/upload-artifact@v6
+        with:
+          name: Rendered site (Antora)
+          path: build/site
+          retention-days: 14
+      ```
+      Check out with `submodules: recursive` and stage the cover logo before the
+      build (copy `docs-resources/images/risc-v_logo.svg` into
+      `modules/ROOT/images/`, then pass
+      `--attribute cover-logo=risc-v_logo.svg`). Without it `index.adoc` — the
+      start page, and the first thing a reviewer opens — renders a broken image.
+- [ ] Write the artifact link into `$GITHUB_STEP_SUMMARY` here and in
+      `build-pdf.yml`, using `upload-artifact`'s `artifact-url` output, so the
+      output is one click from the Checks tab. Do **not** post it as a PR
+      comment from these workflows: the `pull_request` token is read-only on
+      fork PRs, so that needs a separate `workflow_run`-triggered workflow.
 
 ## Step 13a — Publish to your own GitHub Pages site (optional)
 

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -11,10 +11,12 @@
 // (antora.yml), which defaults to `common::risc-v_logo.svg` -- a shared asset
 // supplied by the central playbook, so it resolves only on the central site
 // build. A bare local `npm run preview` has no `common` component and logs one
-// expected unresolved image; CI exception-lists that, which also means CI cannot
-// validate this macro -- check it on the dev site after publishing. The GitHub
-// Pages build (scripts/build-pages-site.sh) overrides the attribute with a
-// vendored copy, so its cover renders standalone.
+// expected unresolved image. Both single-repo builds override the attribute with
+// a copy vendored from the docs-resources submodule, so their covers render
+// standalone: the GitHub Pages build (scripts/build-pages-site.sh) and the CI
+// gate (validate-content-source.yml), which publishes its render as a PR preview
+// artifact. The gate therefore does validate this macro -- its exception for
+// `common::` now only absorbs the case where the submodule is unavailable.
 
 [.space-below]
 image::{cover-logo}[id="riscvlogo",role="xs",alt="RISCV"]


### PR DESCRIPTION
Refs #133 — implements directions (1) and the cheap half of (2); see below for why (3) is closed off.

## The premise needed correcting

#133 says the Antora site "is never built for a PR at all". It is never *published* for a PR — but it **is** built on every PR: `validate-content-source.yml` triggers on `pull_request` and runs a full `antora antora-playbook.yml` as its gate, and the playbook ends with `output: dir: ./build/site`. The site was already landing on the runner and being destroyed with it. Same shape as #132, one layer up.

Measured: **4.2 MB, 72 files**.

So this needs no new job, no second Kroki service, and no extra build time — just an upload step on a job that already exists. `scripts/build-pages-site.sh` is deliberately **not** reused: it stamps the version and walks every release tag to build the version selector, which is release-shaped work a PR preview does not want.

## What's here

**1. Upload `build/site` from the gate.** `Rendered site (Antora)`, 14-day retention, uploaded only on a clean gate — a site built from a tree that failed validation would misrepresent the change.

**2. Stage the cover logo for that build.** `antora.yml` sets `cover-logo: common::risc-v_logo.svg`, a cross-component ref that resolves only in the central multi-source build; the gate exception-listed the resulting error. Harmless when this job was only pass/fail — not harmless now, because `index.adoc` is the start page and would greet every reviewer with a broken image. The fix is what `build-pages-site.sh` already does: vendor the SVG out of `docs-resources` (checkout gains `submodules: recursive`) and hard-set the attribute.

*Side effect worth naming:* the gate now actually **validates** the image macro, which it could not while it was ignoring the error. The `common::` exception stays, but is now the fallback path only — it keeps an unavailable submodule a warning instead of a red gate.

**3. Artifact links in `$GITHUB_STEP_SUMMARY`,** in this workflow and `build-pdf.yml`, from `upload-artifact`'s `artifact-url` output. GitHub documents that output for exactly this. It replaces the issue's five-step scroll-hunt with one click from the Checks tab, needs no permissions, and works on fork PRs.

**Incidental:** the gate now runs `./node_modules/.bin/antora` instead of `npx antora`, matching `build-pages-site.sh`. npx routes argv through npm's own option parser, which claims bare `key=value` arguments (`npm warn "cover-logo=..." is being parsed as a normal command line argument`). Honest caveat: I could not verify the `npx` path locally at all — `npx antora` is broken outright under my npm 11 regardless of the new flag — so I moved to the invocation I *could* verify.

## Deliberately not here

**A PR comment (direction 2, the other half).** It cannot be a step in these workflows: `pull_request` from a fork gets a read-only `GITHUB_TOKEN`, and a template seeded into many repos will get fork PRs. The correct shape is a separate `workflow_run`-triggered workflow holding `pull-requests: write` that never checks out PR code, plus PR-number resolution by head SHA (`workflow_run.pull_requests` is empty for forks). ~80 lines and a security pattern every downstream maintainer has to understand — worth doing, worth its own PR.

**A real per-PR preview host (direction 3).** Not just "large" — it does not work here. `publish-site.yml` already documents that the RISC-V org refuses Pages site creation to the workflow token ("Resource not accessible by integration"), so a Pages-based per-PR preview fails in the exact org this template targets. Netlify/Cloudflare need deploy secrets, which fork PRs cannot access, and would impose a hosting account on every seeded repo.

**One limit no design here removes:** `artifact-url` only works for signed-in users — GitHub's docs say anonymous downloads get a login prompt. Anonymous preview requires real hosting, i.e. direction (3). The run summary says so explicitly rather than leaving reviewers to discover it.

## Verification

Ran the gate's build-step logic locally against a live Kroki, both paths:

- **Logo staged:** exits 0, **zero** error-level log lines, and the output resolves — `img src="_images/risc-v_logo.svg"` in `index.html`, with the file present at `build/site/spec-sample/v0.0/_images/risc-v_logo.svg`.
- **Degraded (logo absent):** exactly one error, `target of image not found: common::risc-v_logo.svg`, absorbed by the retained exception; gate still green.

That is the claim about the exception becoming fallback-only, checked rather than asserted. `pre-commit run` passes on all six files (`check-yaml`, `yamlfmt`, whitespace).

## Note on merge order

Touches the same `Upload Build Artifacts` step in `build-pdf.yml` as #135 (adds `id: upload` where that PR widens `path:`). Expect a small conflict in that hunk; whichever lands second resolves it by keeping both.

## Docs updated

`ANTORA.md` (cover-logo section + Phase 6), `MIGRATION.md` Step 13, `CHANGELOG.md`, and the comment in `modules/ROOT/pages/index.adoc` that told readers CI could not validate this macro — no longer true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)