### PR TITLE
docs: add a guide for upgrading a repo to a newer template version

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -9,6 +9,8 @@ NOTE: If you are viewing this in a specification repository, kindly update the t
 **ARC submissions:** Specifications submitted to the Architecture Review Committee (ARC) must follow the conventions in link:ARC_SUBMISSION.md[ARC_SUBMISSION.md] — versioned GitHub tag, PDF named `<short>-v<MAJOR>.<MINOR>-<YYYYMMDD>.pdf`, and a title page that matches. The Makefile and CI workflows in this template produce ARC-compliant artifacts on every build by default.
 
 **Migrating an existing repo?** See link:MIGRATION.md[MIGRATION.md] for the step-by-step checklist to bring a downstream fork in line with the current toolchain — both the ARC submission PDF and the Antora site, which share one source tree. See link:ANTORA.md[ANTORA.md] for how that dual build works and why.
+
+**Already on the current toolchain?** See link:UPGRADING.md[UPGRADING.md] for how to pick up later template improvements — new workflows, fixed build scripts, ARC compliance changes — in a repository created with *Use this template*, which shares no git history with this one.
 ====
 
 == License

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -92,7 +92,7 @@ nothing per-repository — genuinely tier 1.
 `CONTRIBUTING.md` and `GOVERNANCE.md` are tier 1 *unless* your task group has
 amended them; if so, move them to tier 2.
 
-### Tier 2 — Shared: hand-merge, keep your values
+### Shared files
 
 These carry template structure **and** your customizations on the same lines.
 Never overwrite; always diff and transplant.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -53,7 +53,7 @@ Upgrades are tractable because the template has a clean split between files it
 owns and files you own. Classify every path into one of three tiers **once**, and
 every future upgrade becomes a mechanical application of those rules.
 
-### Tier 1 — Template-owned: take upstream wholesale
+### Template-owned
 
 These have no per-repository content. Overwrite them without reading the diff
 closely; if you have edited one of these locally, that edit is a fork you will be

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,7 +6,7 @@ indefinitely. It is not a one-shot copy. But it is not `git pull` either — the
 mechanism has to be set up deliberately, because GitHub's "Use this template"
 severs the link.
 
-**Who this is for:** maintainers of a specification repository that was created
+**Who this is for:** Maintainers of a specification repository that was created
 from `docs-spec-template` (via *Use this template* or a fork) and wants to pick
 up later toolchain improvements — new workflows, fixed build scripts, ARC
 compliance changes — without losing their specification content.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,460 @@
+# Upgrading a Spec Repository to a Newer Template Version
+
+**Short answer: yes.** A repository created from `docs-spec-template` can be
+upgraded to a later version of the template, and can keep being upgraded
+indefinitely. It is not a one-shot copy. But it is not `git pull` either — the
+mechanism has to be set up deliberately, because GitHub's "Use this template"
+deliberately severs the link.
+
+**Who this is for:** maintainers of a specification repository that was created
+from `docs-spec-template` (via *Use this template* or a fork) and wants to pick
+up later toolchain improvements — new workflows, fixed build scripts, ARC
+compliance changes — without losing their specification content.
+
+**How this differs from the other guides in this repo:**
+
+| Guide | Question it answers |
+| --- | --- |
+| `MIGRATION.md` | "My repo predates the Antora dual build. How do I adopt the current toolchain once?" |
+| **`UPGRADING.md`** (this) | "I'm already on the toolchain. How do I keep up with the template as it changes?" |
+| `ANTORA.md` | "Why is the dual build designed this way?" |
+| `ARC_SUBMISSION.md` | "What does the ARC actually require?" |
+
+If you have never adopted the dual build, do `MIGRATION.md` first. This guide
+assumes your repo already has `scripts/release-info.sh`, `modules/ROOT/`, and
+the current workflows.
+
+---
+
+## 1. Why this needs a procedure at all
+
+When you create a repository with GitHub's **Use this template**, GitHub copies
+the file tree and starts a **brand-new history** — a single initial commit with
+no ancestry shared with `docs-spec-template`. That is usually what you want (your
+spec's history is its own), but it has one consequence:
+
+> Git sees your repo and the template as two unrelated projects. There is no
+> common ancestor, so there is no automatic three-way merge.
+
+Everything below is about restoring enough of a relationship to make upgrades
+mechanical instead of archaeological.
+
+A second, subtler problem: **in your repo, `v*` tags mean *specification*
+versions, not template versions.** `v0.62` is a milestone of your spec, minted by
+`version-bot.yml`. Nothing in a downstream repo records which template version it
+was built from — so before you can upgrade, you have to establish a baseline and
+write it down. Section 3 does that.
+
+---
+
+## 2. The file contract
+
+Upgrades are tractable because the template has a clean split between files it
+owns and files you own. Classify every path into one of three tiers **once**, and
+every future upgrade becomes a mechanical application of those rules.
+
+### Tier 1 — Template-owned: take upstream wholesale
+
+These have no per-repository content. Overwrite them without reading the diff
+closely; if you have edited one of these locally, that edit is a fork you will be
+re-doing forever, and it belongs upstream instead.
+
+```
+scripts/release-info.sh
+scripts/stamp-antora-version.sh
+scripts/update-spec-state.sh
+scripts/build-pages-site.sh
+scripts/gen-pages-playbook.js
+tests/release-info-test.sh
+.github/workflows/build-pdf.yml
+.github/workflows/version-bot.yml
+.github/workflows/publish-site.yml
+.github/workflows/validate-content-source.yml
+.github/workflows/pre-commit.yml
+.github/workflows/vale-linting.yml
+.github/dependabot.yml
+.pre-commit-config.yaml
+.vale.ini
+docker-compose.yml
+ANTORA.md
+MIGRATION.md
+ARC_SUBMISSION.md
+LICENSE
+CODE_OF_CONDUCT.md
+GOVERNANCE.md
+```
+
+`scripts/build-pages-site.sh` mentions `spec-sample`, but only in comments. It
+reads `version:` from `antora.yml` at runtime, and the component name reaches it
+via `start_page` in `antora-playbook.yml` (tier 2), so the script itself carries
+nothing per-repository — genuinely tier 1.
+
+`CONTRIBUTING.md` and `GOVERNANCE.md` are tier 1 *unless* your task group has
+amended them; if so, move them to tier 2.
+
+### Tier 2 — Shared: hand-merge, keep your values
+
+These carry template structure **and** your customizations on the same lines.
+Never overwrite; always diff and transplant.
+
+| File | What is yours |
+| --- | --- |
+| `Makefile` | `DOCS` (your top-level `.adoc`), `SPEC_SHORT` |
+| `antora.yml` | `name`, `title`, `asamBibliography`; `version`/`page-*` are **stamped**, never hand-edited |
+| `antora-playbook.yml` | `start_page: <your-component>::index.adoc` |
+| `package.json` | `name` field; devDependency **versions** are tier 1 |
+| `README.adoc` | Almost entirely yours, but upstream adds sections (setup checklist, new build steps) worth harvesting |
+| `CHANGELOG.md` | Yours; see §5 for how to log the upgrade itself |
+| `.gitignore` | Usually identical; upstream adds entries as generated artifacts appear |
+| `.gitmodules` | Usually identical — verify rather than assume |
+
+### Tier 3 — Yours: never take upstream
+
+```
+modules/ROOT/pages/*.adoc      your chapters
+modules/ROOT/nav.adoc          your site navigation
+modules/ROOT/resources/*.bib   your bibliography
+SPEC_STATE.md                  maintained by update-spec-state.sh
+MAINTAINERS.md
+```
+
+### The one genuine exception: `src/<your-spec>.adoc`
+
+Your PDF assembler is tier 3 by ownership — it names your chapters — but it is
+**tier 1 by shape**. Everything around the `include::` lines is template
+scaffolding that changes when ARC requirements change: the `[preface] ==
+Document State` block, the `toc::[]` placement, the `list-of::` macros, the
+`[index]` position before the bibliography, the `ifndef::` attribute defaults.
+
+> **Diff `src/spec-sample.adoc` against your assembler on every upgrade, even
+> though you never copy it wholesale.** This is the single most common source of
+> a repo that upgrades cleanly and then fails ARC review, because the compliance
+> requirements live in exactly the file the tiering says not to touch.
+
+### Files to drop if you inherited them
+
+`0001-Automate-Versioning.patch` is a historical artifact of the template. It has
+no function in a spec repository — delete it.
+
+---
+
+## 3. One-time setup
+
+Do this once, on a branch. It costs ten minutes and makes every subsequent
+upgrade a routine operation.
+
+### 3.1 Add the template as a remote
+
+```shell
+git remote add template https://github.com/riscv/docs-spec-template.git
+git fetch template
+```
+
+Naming it `template` (not `upstream`) matters if your repo is also a fork of
+something else.
+
+### 3.2 Establish and record your baseline
+
+Determine which template state your repo currently matches. If you know the
+release you started from, use it. If you don't, find the closest match by
+diffing tier 1 against candidate refs:
+
+```shell
+for ref in v4.0.0 v4.0.1 v4.0.2 v4.0.3 v4.0.4 template/main; do
+  n=$(git diff --name-only "$ref" -- scripts .github/workflows 2>/dev/null | wc -l)
+  printf '%-20s %s differing files\n' "$ref" "$n"
+done
+```
+
+The ref with the fewest differences is your baseline.
+
+Now record it. **This file does not exist in the template today — you are
+introducing the convention**, and it is the piece that makes upgrades repeatable
+rather than exploratory:
+
+```shell
+cat > .template-version <<'EOF'
+# Which docs-spec-template release this repository's tooling tracks.
+# Updated by the upgrade procedure in UPGRADING.md. Not a spec version --
+# spec versions are the v* git tags minted by version-bot.yml.
+template_ref: v4.0.4
+template_sha: <full SHA of that ref>
+upgraded_on: 2026-08-17
+EOF
+git add .template-version
+```
+
+Use `git rev-parse v4.0.4` to fill in the SHA. Recording the SHA as well as the
+ref matters because the template's tag namespace is shared with its own version-bot
+test tags (`vtest`, `v0.01`, `v1.0_rc1`), and tags can move; a SHA cannot.
+
+### 3.3 Pinning when there is no suitable tag
+
+The template's semver release line (`v1.0.0` → `v4.0.4`) currently lags `main`:
+substantial work — the Antora dual build, the GitHub Pages publish, the PR
+preview artifact — sits unreleased under `[Unreleased]` in `CHANGELOG.md`. If the
+feature you need is not in a tag yet, **pin to a commit SHA** on `template/main`
+and record that SHA. Do not track a moving `template/main`.
+
+---
+
+## 4. The upgrade procedure
+
+### 4.1 Decide what you are taking
+
+```shell
+git fetch template
+git log --oneline <your-recorded-sha>..template/main
+git diff <your-recorded-sha>..template/main -- CHANGELOG.md
+```
+
+Read the changelog range first. The template's changelog is where breaking
+toolchain changes are described in prose; the commit list tells you what moved,
+the changelog tells you what it means for you.
+
+### 4.2 Branch
+
+```shell
+git switch -c chore/template-upgrade-<target>
+```
+
+### 4.3 Take tier 1 wholesale
+
+`git checkout` from a ref applies upstream's version of specific paths directly
+into your working tree — no merge, no conflicts, no shared history required:
+
+```shell
+TARGET=template/main   # or a tag, or a pinned SHA
+
+git checkout $TARGET -- \
+  scripts/ tests/ \
+  .github/workflows/ .github/dependabot.yml \
+  .pre-commit-config.yaml .vale.ini docker-compose.yml \
+  ANTORA.md MIGRATION.md ARC_SUBMISSION.md UPGRADING.md
+```
+
+Then review what you just staged — this is the check that catches a tier-1 file
+you had quietly customized:
+
+```shell
+git diff --cached --stat
+```
+
+### 4.4 Hand-merge tier 2
+
+For each tier 2 file, look at what changed upstream and transplant it:
+
+```shell
+git diff <your-recorded-sha>..$TARGET -- Makefile antora.yml antora-playbook.yml package.json
+```
+
+Apply upstream's changes to your copy by hand, preserving your values from the
+table in §2. Concretely, on a `Makefile` upgrade you keep your `DOCS` and
+`SPEC_SHORT` lines and take everything else.
+
+For `package.json`, take upstream's `devDependencies` versions and keep your
+`name`. Then regenerate the lockfile rather than merging it:
+
+```shell
+npm install --package-lock-only
+```
+
+### 4.5 Check the assembler
+
+```shell
+git diff <your-recorded-sha>..$TARGET -- src/
+```
+
+Apply any structural change (new preface block, changed `toc::[]` or `[index]`
+placement, new `ifndef::` default) to your own `src/<your-spec>.adoc`, keeping
+your `include::` lines. See the warning in §2.
+
+### 4.6 Update the submodule
+
+`docs-resources` upgrades on its own cadence — Dependabot proposes bumps
+independently of template releases — but pick up the template's current pointer
+during an upgrade so your build matches what upstream tested:
+
+```shell
+git checkout $TARGET -- docs-resources
+git submodule update --init --recursive
+```
+
+### 4.7 Record the new baseline
+
+Update `.template-version` with the new ref, SHA, and date. An upgrade that does
+not update this file has made the next upgrade harder than it needed to be.
+
+---
+
+## 5. Verify before you merge
+
+Run all of these. They are ordered cheapest-first.
+
+```shell
+# 1. Helper-script unit tests -- catches release-info.sh regressions
+tests/release-info-test.sh          # exit 0 = all passed
+
+# 2. Version metadata resolves
+./scripts/release-info.sh version
+./scripts/release-info.sh phase "$(./scripts/release-info.sh version)"
+
+# 3. Full PDF build
+make clean && make build
+```
+
+Then confirm the **ARC filename** is correct — this is the check that matters
+most, because a wrong filename is an outright ARC rejection:
+
+```shell
+ls build/*.pdf
+```
+
+You must see `<SPEC_SHORT>-v<MAJOR>.<MINOR>-<YYYYMMDD>.pdf`. If you see a bare
+`<name>.pdf`, your `SPEC_SHORT` did not survive the `Makefile` merge.
+
+Open the PDF and check page 1 (title, version, date) and page 2 (the *Document
+State* preface with the phase notice) against `ARC_SUBMISSION.md`.
+
+Finally, the site:
+
+```shell
+npm install
+docker compose up -d kroki
+npm run preview                     # -> build/site/
+```
+
+Citations and the bibliography render as raw text in local preview — that is
+expected, not a regression. The `cite:` and `bibliography::[]` macros are
+resolved by the central playbook's ASAM extension, which is not bundled here.
+
+To reproduce exactly what CI publishes to Pages:
+
+```shell
+NO_STAMP=1 ./scripts/build-pages-site.sh    # -> build/pages-site/
+```
+
+### Post-merge checks
+
+CI on the PR exercises the rest: the PDF build, `pre-commit`, Vale, and the
+Antora content-source gate — which now attaches the rendered site as a *Rendered
+site (Antora)* artifact, so you can click through the upgraded site before
+merging.
+
+After merging, dispatch `version-bot.yml` **only when you actually intend to cut
+a release**. A template upgrade is not a specification revision; merging to
+`main` does not tag one, and it should not.
+
+---
+
+## 6. What upgrades tend to break
+
+Ordered by how often they bite.
+
+1. **`SPEC_SHORT` lost in a `Makefile` merge** → non-compliant PDF filename.
+   Caught by §5's `ls build/*.pdf`.
+2. **`antora.yml` overwritten wholesale** → your component `name` reverts to
+   `spec-sample`, which silently changes the published site URL and orphans the
+   central playbook's registration. Never `git checkout` this file from upstream.
+3. **A stamped value hand-edited.** `version`, `page-revnumber`, `page-revdate`,
+   and the `page-phase*` attributes in `antora.yml` come from
+   `stamp-antora-version.sh`, which reads `release-info.sh` — the same source the
+   PDF uses. Editing them by hand desyncs the site from the PDF, which the ARC
+   Author Guide requires to match exactly. Run `make stamp-antora` instead.
+4. **`nav.adoc` numbering rules.** Chapter numbering on the published central
+   site is keyed to the **line numbers of the `xref` entries in
+   `modules/ROOT/nav.adoc`**, via `numbering_rules` in the central playbook —
+   not by anything in this repo. An upgrade that reorders your nav requires a
+   matching update in `github.com/riscv-admin/antora.riscv.org`. See *Section
+   numbering* in `ANTORA.md`.
+5. **New workflows need new repository settings.** A workflow that arrives in an
+   upgrade may need configuration that a running repo never had. Re-read the
+   *Repository Setup Checklist* in `README.adoc` after every upgrade —
+   particularly the `GHTOKEN` secret (without it, bot-opened PRs have all their
+   checks stall in `action_required`) and *Settings → Pages → Source: GitHub
+   Actions*, which a RISC-V org admin must set by hand because the org restricts
+   Pages creation and the workflow's own token is refused.
+6. **Submodule left uninitialized** after `git checkout template/main --
+   docs-resources`. `make build` auto-initializes, but `npm run preview` and
+   `build-pages-site.sh` will fail on the missing cover logo first.
+
+---
+
+## 7. Rolling back
+
+Because tier 1 is applied by `git checkout` rather than merged, reverting is
+clean — there is no merge commit to unpick:
+
+```shell
+git switch main            # abandon the upgrade branch entirely
+```
+
+Or, after the fact, revert the upgrade commit:
+
+```shell
+git revert --no-commit <upgrade-commit>
+git submodule update --init --recursive
+```
+
+Then restore the previous values in `.template-version`.
+
+---
+
+## 8. Alternative strategies
+
+The path-checkout approach in §4 is the recommended one: no shared history
+required, no merge conflicts, and the tiering is enforced by which paths you
+type. Two alternatives exist, both with real costs.
+
+### Unrelated-histories merge
+
+```shell
+git merge template/main --allow-unrelated-histories
+```
+
+**Gains:** real three-way merges after the first one, so tier 2 files merge
+semi-automatically and later upgrades know what you already took.
+
+**Costs:** the first merge conflicts on essentially every tier 3 file at once —
+Git has no common ancestor, so your chapters conflict with `spec-sample`'s. You
+resolve a large conflict set by hand, and any mistake silently reverts spec
+content. The template's history also becomes permanently interleaved with your
+spec's, which makes `git log` on your own content noisier forever.
+
+Worth it only if you expect to track the template closely and continuously.
+Resolve that first merge with `git checkout --ours` on all of tier 3.
+
+### Cherry-picking individual commits
+
+```shell
+git cherry-pick -x <template-commit>
+```
+
+Works when you want one specific upstream fix and nothing else. Fine for a
+targeted hotfix; unworkable as a general strategy, because template changes
+routinely span a workflow, a script, and a doc in separate commits, and picking a
+subset produces states upstream never tested.
+
+---
+
+## 9. Cadence
+
+- **Per upgrade:** log it in your `CHANGELOG.md` under `[Unreleased]`, naming the
+  template ref you moved to. Your changelog is the only place a reader of your
+  repo will find out that the toolchain moved.
+- **Before any ARC submission:** upgrade first, then cut the release. ARC
+  compliance requirements change in the template; submitting from a stale
+  toolchain is the most common way to fail on format rather than content.
+- **Otherwise:** on a milestone boundary (`v0.6`, `v0.8`, `v0.9`, `v0.99`,
+  `v1.0`) is a natural rhythm — those are already governance checkpoints where
+  the `SPEC_STATE.md` PR gets maintainer attention.
+
+Do not upgrade between a `version-bot.yml` dispatch and the release build it
+triggers.
+
+---
+
+## Questions
+
+Open an issue on `github.com/riscv/docs-spec-template` — a tier 1 file that you
+had to customize locally is a template bug, and worth reporting as one.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,63 +1,468 @@
 # Upgrading a Spec Repository to a Newer Template Version
 
-**Short answer: yes.** A repository created from `docs-spec-template` can be
-upgraded to a later version of the template, and can keep being upgraded
-indefinitely. It is not a one-shot copy. But it is not `git pull` either — the
-mechanism has to be set up deliberately, because GitHub's "Use this template"
-severs the link.
+## Can I upgrade a repository I created from this template?
+
+Short answer: yes. A repository created from `docs-spec-template` can be upgraded
+to a later version of the template, and can keep being upgraded indefinitely. It
+is not a one-shot copy. But it is not `git pull` either — the mechanism has to be
+set up deliberately, because GitHub's "Use this template" severs the link.
 
 **Who this is for:** Maintainers of a specification repository that was created
 from `docs-spec-template` (via *Use this template* or a fork) and wants to pick
 up later toolchain improvements — new workflows, fixed build scripts, ARC
 compliance changes — without losing their specification content.
 
-**How this differs from the other guides in this repo:**
+> **Before you start:** this guide assumes your repository already has
+> `scripts/release-info.sh`, `modules/ROOT/`, and the current workflows. If it
+> does not, you have not adopted the Antora dual build yet. Work through
+> [`MIGRATION.md`](MIGRATION.md) first, then come back here.
 
-| Guide | Question it answers |
-| --- | --- |
-| `MIGRATION.md` | "My repo predates the Antora dual build. How do I adopt the current toolchain once?" |
-| **`UPGRADING.md`** (this) | "I'm already on the toolchain. How do I keep up with the template as it changes?" |
-| `ANTORA.md` | "Why is the dual build designed this way?" |
-| `ARC_SUBMISSION.md` | "What does the ARC actually require?" |
-
-If you have never adopted the dual build, do `MIGRATION.md` first. This guide
-assumes your repo already has `scripts/release-info.sh`, `modules/ROOT/`, and
-the current workflows.
+The procedure is in sections 1–3. If you want to know *why* it works this way, or
+which files belong to whom, see the [Reference](#reference) at the end.
 
 ---
 
-## 1. Why this needs a procedure at all
+## 1. Before you begin
 
-When you create a repository with GitHub's **Use this template**, GitHub copies
-the file tree and starts a **brand-new history** — a single initial commit with
-no ancestry shared with `docs-spec-template`. That is usually what you want (your
-spec's history is its own), but it has one consequence:
+Before you upgrade, add the spec template repository as a remote and record which
+template version your repository is currently on. Do these steps once, on a
+branch, and every subsequent upgrade becomes a routine operation.
 
-> Git sees your repo and the template as two unrelated projects. There is no
-> common ancestor, so there is no automatic three-way merge.
+### 1.1 Add the template as a remote
 
-Everything below is about restoring enough of a relationship to make upgrades
-mechanical instead of archaeological.
+```shell
+git remote add template https://github.com/riscv/docs-spec-template.git
+git fetch template
+```
 
-A second, subtler problem: **in your repo, `v*` tags mean *specification*
-versions, not template versions.** `v0.62` is a milestone of your spec, maintained by
-`version-bot.yml`. Nothing in a downstream repo records which template version it
-was built from — so before you can upgrade, you have to establish a baseline and
-write it down. Section 3 does that.
+Name it `template`, not `upstream`. If your repository is also a fork of
+something else, `upstream` will already be taken.
+
+### 1.2 Find your baseline
+
+You need to know which template release your repository currently matches. If you
+know which release you started from, use that and skip to 1.3.
+
+If you do not know, find the closest match by comparing the template-owned files
+against each candidate release:
+
+```shell
+for ref in v4.0.0 v4.0.1 v4.0.2 v4.0.3 v4.0.4 template/main; do
+  n=$(git diff --name-only "$ref" -- scripts .github/workflows 2>/dev/null | wc -l)
+  printf '%-20s %s differing files\n' "$ref" "$n"
+done
+```
+
+For example, this output:
+
+```
+v4.0.0                      3 differing files
+v4.0.1                      7 differing files
+v4.0.2                      9 differing files
+v4.0.3                     11 differing files
+v4.0.4                     11 differing files
+template/main              12 differing files
+```
+
+The fewest differences are against `v4.0.0`, so that is your baseline. If several
+releases tie, choose the most recent one.
+
+### 1.3 Record your baseline
+
+Now record it by creating a `.template-version` file in your repository. This file
+makes future upgrades much easier: it is the only place that records which
+template version your tooling came from.
+
+> **Note:** `.template-version` does not exist in the template today. You are
+> introducing the convention. It is proposed in the pull request that added this
+> guide, and only pays off if the template adopts it.
+
+First get the full commit SHA of your baseline release:
+
+```shell
+git rev-parse v4.0.0
+```
+
+Then create the file, replacing `template_ref` with your baseline from 1.2 and
+`template_sha` with the SHA that `git rev-parse` just printed:
+
+```shell
+cat > .template-version <<'EOF'
+# Which docs-spec-template release this repository's tooling tracks.
+# Updated by the upgrade procedure in UPGRADING.md. Not a spec version --
+# spec versions are the v* git tags minted by version-bot.yml.
+template_ref: v4.0.0
+template_sha: 0000000000000000000000000000000000000000
+upgraded_on: 2026-08-17
+EOF
+git add .template-version
+```
+
+Record the SHA as well as the release name. The template's tag namespace is shared
+with its own version-bot test tags (`vtest`, `v0.01`, `v1.0_rc1`), and tags can be
+moved to point at a different commit. A SHA cannot.
+
+### 1.4 If no release has what you need
+
+The template's numbered releases (`v1.0.0` through `v4.0.4`) currently lag behind
+its `main` branch. Several significant features — the Antora dual build, the
+GitHub Pages publish, and the pull request preview artifact — are finished and
+merged to `main` but have not been included in a numbered release yet. They are
+listed under `[Unreleased]` in the template's
+[`CHANGELOG.md`](https://github.com/riscv/docs-spec-template/blob/main/CHANGELOG.md).
+
+If you need one of those features, use a commit SHA from `template/main` as your
+baseline instead of a release name:
+
+```shell
+git rev-parse template/main
+```
+
+Record that SHA in `.template-version` and leave `template_ref: template/main`.
+Always pin to a specific SHA. Do not upgrade against `template/main` as a moving
+target, or you will not be able to tell what changed between two upgrades.
 
 ---
 
-## 2. The file contract
+## 2. Upgrade
 
-Upgrades are tractable because the template has a clean split between files it
-owns and files you own. Classify every path into one of three tiers **once**, and
-every future upgrade becomes a mechanical application of those rules.
+### 2.1 Choose your target
+
+Your **target** is the template version you are upgrading *to*. Set it once, as a
+shell variable, and the rest of the commands in this section will use it:
+
+```shell
+TARGET=template/main
+```
+
+Use `template/main` to take the newest template code, or a release name such as
+`v4.0.4` to move to a specific numbered release. If you are pinning to a commit
+(see 1.4), use the SHA.
+
+Set your recorded baseline the same way, taking the value of `template_sha` from
+your `.template-version` file:
+
+```shell
+BASELINE=<the template_sha from .template-version>
+```
+
+### 2.2 See what changed
+
+```shell
+git fetch template
+git log --oneline "$BASELINE".."$TARGET"
+```
+
+Then read the template's changelog for the same range. The commit list tells you
+what moved; the changelog tells you what it means for you, because that is where
+breaking toolchain changes are described in prose.
+
+The easiest way to read it is on GitHub, which renders the changelog and lets you
+browse file by file:
+
+```
+https://github.com/riscv/docs-spec-template/compare/<BASELINE>...<TARGET>
+```
+
+For example: <https://github.com/riscv/docs-spec-template/compare/v4.0.0...main>
+
+> **Note:** the changelog you want is the *template's* `CHANGELOG.md`, not yours.
+> A `git diff -- CHANGELOG.md` in your own repository will show nothing if your
+> repository has no `CHANGELOG.md` of its own, which is normal.
+
+### 2.3 Create a branch
+
+```shell
+git switch -c chore/template-upgrade
+```
+
+### 2.4 Copy the template-owned files
+
+Template-owned files have no per-repository content, so you can take the
+template's version of them wholesale. `git checkout` from a ref copies specific
+paths straight into your working tree — no merge, no conflicts, and no shared
+history required:
+
+```shell
+git checkout $TARGET -- \
+  scripts/ tests/ \
+  .github/workflows/ .github/dependabot.yml \
+  .pre-commit-config.yaml .vale.ini docker-compose.yml \
+  ANTORA.md MIGRATION.md ARC_SUBMISSION.md
+```
+
+For the full list of which files are template-owned and why, see
+[Which files are whose](#a-which-files-are-whose) in the Reference.
+
+Now review what you just staged. This is the check that catches a template-owned
+file you had customized locally without realizing it:
+
+```shell
+git diff --cached --stat
+```
+
+If a file shows up here that you did change on purpose, stop and read that one
+diff before continuing. See the note in the Reference about local edits to
+template-owned files.
+
+### 2.5 Merge the shared files manually
+
+Shared files carry template structure **and** your customizations on the same
+lines, so you cannot copy them. You have to apply the template's changes to your
+copy while keeping your own values.
+
+Look at what changed upstream:
+
+```shell
+git diff --stat "$BASELINE".."$TARGET" -- Makefile antora.yml antora-playbook.yml package.json
+```
+
+That gives you a summary of which files moved and by how much. To read an
+individual file's changes, either open the GitHub compare URL from 2.2 and click
+through the files, or diff one file at a time in the terminal:
+
+```shell
+git diff "$BASELINE".."$TARGET" -- Makefile
+```
+
+Then apply those changes to your copy, keeping the values listed under
+[Shared files](#shared-files) in the Reference. Concretely, on a `Makefile`
+upgrade you keep your `DOCS` and `SPEC_SHORT` lines and take everything else.
+
+For `package.json`, take the template's `devDependencies` versions and keep your
+`name` field. Then regenerate the lockfile rather than merging it:
+
+```shell
+npm install --package-lock-only
+```
+
+### 2.6 Check your PDF assembler
+
+Your `src/<your-spec>.adoc` file is the one file that is both yours and the
+template's at the same time — it names your chapters, but everything around those
+`include::` lines is template scaffolding that changes when ARC requirements
+change. Check it on every upgrade:
+
+```shell
+git diff "$BASELINE".."$TARGET" -- src/
+```
+
+Apply any structural change — a new preface block, a moved `toc::[]` or `[index]`,
+a new `ifndef::` default — to your own assembler, keeping your `include::` lines.
+Never copy `src/spec-sample.adoc` over your own file.
+
+This is the most common reason a repository upgrades cleanly and then fails ARC
+review, because the compliance requirements live in exactly the file that
+ownership rules say not to touch. See
+[The one file that is both](#the-one-file-that-is-both) in the Reference.
+
+### 2.7 Update the submodule
+
+`docs-resources` upgrades on its own schedule — Dependabot proposes bumps
+independently of template releases — but take the template's current pointer
+during an upgrade so your build matches what the template tested:
+
+```shell
+git checkout $TARGET -- docs-resources
+git submodule update --init --recursive
+```
+
+### 2.8 Record the new baseline
+
+Update `.template-version` with the new ref, SHA, and today's date. If you do not
+update this file now, your next upgrade will start back at the beginning, working
+out your baseline from scratch.
+
+### 2.9 Open a pull request
+
+Everything so far has changed files in your local working tree only. Commit and
+push the branch to open a pull request:
+
+```shell
+git add -A
+git commit -m "chore: upgrade template to <target>"
+git push -u origin chore/template-upgrade
+```
+
+Opening a pull request is also what runs the CI checks described in section 3.
+
+---
+
+## 3. Verify
+
+### 3.1 Check it locally
+
+Run all of these. The quickest ones are first, so a failure stops you early.
+
+Start with the helper-script unit tests, which catch `release-info.sh`
+regressions:
+
+```shell
+tests/release-info-test.sh
+```
+
+Exit code 0 means everything passed. Next, confirm your version metadata still
+resolves:
+
+```shell
+./scripts/release-info.sh version
+./scripts/release-info.sh phase "$(./scripts/release-info.sh version)"
+```
+
+Then run a full PDF build:
+
+```shell
+make clean && make build
+```
+
+Now check the built PDF's filename:
+
+```shell
+ls build/*.pdf
+```
+
+You should see `<SPEC_SHORT>-v<MAJOR>.<MINOR>-<YYYYMMDD>.pdf`. If you see a bare
+`<name>.pdf` instead, your `SPEC_SHORT` value did not survive the `Makefile`
+merge in 2.5. Reopen your `Makefile`, restore the `SPEC_SHORT` line from your
+pre-upgrade version, and run `make clean && make build` again.
+
+Open the PDF and check page 1 (title, version, date) and page 2 (the *Document
+State* preface with the phase notice). Both are checked at ARC submission time,
+and an upgrade can change either of them, so it is worth confirming now rather
+than discovering it during a submission.
+
+Finally, build the site:
+
+```shell
+npm install
+docker compose up -d kroki
+npm run preview
+```
+
+That writes to `build/site/`. Citations and the bibliography will render as raw
+text in this local preview. That is expected and not a regression — the `cite:`
+and `bibliography::[]` macros are resolved by the central playbook's ASAM
+extension, which is not bundled in this repository.
+
+To reproduce exactly what CI publishes to GitHub Pages, which does include those
+macros:
+
+```shell
+NO_STAMP=1 ./scripts/build-pages-site.sh
+```
+
+That writes to `build/pages-site/`.
+
+### 3.2 What CI checks on your pull request
+
+Once you push the branch and open a pull request, CI runs the PDF build,
+`pre-commit`, Vale, and a check that your repository can still be consumed by the
+central Antora site.
+
+That last check also builds your site and attaches it to the pull request as a
+*Rendered site (Antora)* artifact. You do not have to look at it, but downloading
+it and clicking through a few sections is the fastest way to confirm an upgrade
+did not break your navigation or page structure before you merge.
+
+### 3.3 After you merge
+
+Run `version-bot.yml` **only when you actually intend to cut a release**. A
+template upgrade is not a specification revision. Merging it to `main` does not
+tag one, and it should not.
+
+---
+
+## 4. What upgrades tend to break
+
+These are the most common problems, most frequent first.
+
+1. **`SPEC_SHORT` lost in a `Makefile` merge**, which produces a non-compliant PDF
+   filename. Caught by the `ls build/*.pdf` check in 3.1.
+2. **`antora.yml` overwritten wholesale.** Your component `name` reverts to
+   `spec-sample`, which silently changes the published site URL and breaks the
+   central playbook's registration of your component. Never `git checkout` this
+   file from the template.
+3. **A stamped value edited manually.** The `version`, `page-revnumber`,
+   `page-revdate`, and `page-phase*` attributes in `antora.yml` are generated by
+   `stamp-antora-version.sh`, which reads `release-info.sh` — the same source the
+   PDF uses. Editing them manually desyncs the site from the PDF, which the ARC
+   Author Guide requires to match exactly. Run `make stamp-antora` instead.
+4. **`nav.adoc` reordered without a matching central update.** Chapter numbering on
+   the published central site is keyed to the *line numbers* of the `xref` entries
+   in `modules/ROOT/nav.adoc`, via `numbering_rules` in the central playbook — not
+   by anything in your repository. If an upgrade reorders your nav, it needs a
+   matching update in `github.com/riscv-admin/antora.riscv.org`. See *Section
+   numbering* in [`ANTORA.md`](ANTORA.md).
+5. **New workflows need new repository settings.** A workflow that arrives in an
+   upgrade may need configuration that a running repository never had. Re-read the
+   *Repository Setup Checklist* in [`README.adoc`](README.adoc) after every
+   upgrade. Two in particular: the `GHTOKEN` secret, without which bot-opened pull
+   requests have all their checks stall in `action_required`; and *Settings →
+   Pages → Source: GitHub Actions*, which a RISC-V org admin has to set manually
+   because the org restricts Pages creation and the workflow's own token is
+   refused.
+6. **Submodule left uninitialized** after `git checkout $TARGET -- docs-resources`.
+   `make build` initializes it automatically, but `npm run preview` and
+   `build-pages-site.sh` will fail on the missing cover logo first.
+
+---
+
+## 5. Rolling back
+
+Because the template-owned files are copied with `git checkout` rather than
+merged, reverting is clean — there is no merge commit to unpick.
+
+To abandon an upgrade you have not merged yet, just leave the branch:
+
+```shell
+git switch main
+```
+
+To undo an upgrade you already merged, revert the commit and reset the submodule:
+
+```shell
+git revert --no-commit <upgrade-commit>
+git submodule update --init --recursive
+```
+
+Then restore the previous values in `.template-version`.
+
+---
+
+## 6. When to upgrade
+
+- **Before any ARC submission.** Upgrade first, then cut the release. ARC
+  compliance requirements change in the template, and submitting from a stale
+  toolchain is the most common way to fail on format rather than content.
+- **Otherwise,** on a milestone boundary (`v0.6`, `v0.8`, `v0.9`, `v0.99`, `v1.0`)
+  is a natural rhythm. Those are already governance checkpoints where the
+  `SPEC_STATE.md` pull request gets maintainer attention.
+- **Never** between a `version-bot.yml` run and the release build it triggers.
+
+Log each upgrade in your `CHANGELOG.md` under `[Unreleased]`, naming the template
+ref you moved to. This matters to two audiences: your own maintainers, who
+otherwise have no record that the toolchain moved; and the template maintainers,
+who need to know which template version a repository is on in order to help you
+when a build breaks.
+
+---
+
+# Reference
+
+Background material. You do not need any of it to run the procedure above.
+
+## A. Which files are whose
+
+The template has a clean split between files it owns and files you own. Classify
+every path once, and every future upgrade becomes a mechanical application of
+those rules.
 
 ### Template-owned
 
 These have no per-repository content. Overwrite them without reading the diff
-closely; if you have edited one of these locally, that edit is a fork you will be
-re-doing forever, and it belongs upstream instead.
+closely. If you have edited one of these locally, that edit is a fork you will be
+re-doing on every upgrade forever, and it belongs upstream instead — please open
+an issue on the template.
 
 ```
 scripts/release-info.sh
@@ -79,6 +484,7 @@ docker-compose.yml
 ANTORA.md
 MIGRATION.md
 ARC_SUBMISSION.md
+UPGRADING.md
 LICENSE
 CODE_OF_CONDUCT.md
 GOVERNANCE.md
@@ -86,29 +492,52 @@ GOVERNANCE.md
 
 `scripts/build-pages-site.sh` mentions `spec-sample`, but only in comments. It
 reads `version:` from `antora.yml` at runtime, and the component name reaches it
-via `start_page` in `antora-playbook.yml` (tier 2), so the script itself carries
-nothing per-repository — genuinely tier 1.
+via `start_page` in `antora-playbook.yml`, so the script itself carries nothing
+per-repository.
 
-`CONTRIBUTING.md` and `GOVERNANCE.md` are tier 1 *unless* your task group has
-amended them; if so, move them to tier 2.
+`CONTRIBUTING.md` and `GOVERNANCE.md` are template-owned *unless* your task group
+has amended them. If so, treat them as shared files.
+
+`UPGRADING.md` is listed here, but note that your repository will not have a copy
+until the template ships this guide in a release. Add it to the `git checkout`
+command in 2.4 once it exists upstream.
 
 ### Shared files
 
-These carry template structure **and** your customizations on the same lines.
-Never overwrite; always diff and transplant.
+These carry template structure **and** your customizations on the same lines. Do
+not overwrite them. Read the template's changes and apply them to your copy,
+keeping your own values from this table.
 
 | File | What is yours |
 | --- | --- |
 | `Makefile` | `DOCS` (your top-level `.adoc`), `SPEC_SHORT` |
-| `antora.yml` | `name`, `title`, `asamBibliography`; `version`/`page-*` are **stamped**, never hand-edited |
+| `antora.yml` | `name`, `title`, `asamBibliography`; `version`/`page-*` are **generated**, never edited manually |
 | `antora-playbook.yml` | `start_page: <your-component>::index.adoc` |
-| `package.json` | `name` field; devDependency **versions** are tier 1 |
-| `README.adoc` | Almost entirely yours, but upstream adds sections (setup checklist, new build steps) worth harvesting |
-| `CHANGELOG.md` | Yours; see §5 for how to log the upgrade itself |
-| `.gitignore` | Usually identical; upstream adds entries as generated artifacts appear |
-| `.gitmodules` | Usually identical — verify rather than assume |
+| `package.json` | `name` field; devDependency **versions** are template-owned |
+| `README.adoc` | Almost entirely yours, but the template adds sections (setup checklist, new build steps) worth taking |
+| `CHANGELOG.md` | Yours; see section 6 for how to log the upgrade itself |
+| `.gitignore` | Usually identical; the template adds entries as new generated artifacts appear |
+| `.gitmodules` | Usually identical — check rather than assume |
+| `src/<your-spec>.adoc` | Your `include::` lines only; see below |
+
+#### The one file that is both
+
+`src/<your-spec>.adoc` is the hardest file in this list, because ownership and
+structure point in opposite directions. The file is yours — it names your
+chapters — but everything around the `include::` lines is template scaffolding
+that changes when ARC requirements change: the `[preface] == Document State`
+block, the `toc::[]` placement, the `list-of::` macros, the `[index]` position
+before the bibliography, and the `ifndef::` attribute defaults.
+
+> Compare `src/spec-sample.adoc` against your own assembler on every upgrade,
+> even though you never copy it over. This is the single most common source of a
+> repository that upgrades cleanly and then fails ARC review, because the
+> compliance requirements live in exactly the file that ownership rules say not
+> to touch.
 
 ### Specification-specific files
+
+Never take the template's version of these.
 
 ```
 modules/ROOT/pages/*.adoc      your chapters
@@ -118,343 +547,64 @@ SPEC_STATE.md                  maintained by update-spec-state.sh
 MAINTAINERS.md
 ```
 
-### The one genuine exception: `src/<your-spec>.adoc`
-
-Your PDF assembler is tier 3 by ownership — it names your chapters — but it is
-**tier 1 by shape**. Everything around the `include::` lines is template
-scaffolding that changes when ARC requirements change: the `[preface] ==
-Document State` block, the `toc::[]` placement, the `list-of::` macros, the
-`[index]` position before the bibliography, the `ifndef::` attribute defaults.
-
-> **Diff `src/spec-sample.adoc` against your assembler on every upgrade, even
-> though you never copy it wholesale.** This is the single most common source of
-> a repo that upgrades cleanly and then fails ARC review, because the compliance
-> requirements live in exactly the file the tiering says not to touch.
-
-### Files to drop if you inherited them
+### Files to delete if you inherited them
 
 `0001-Automate-Versioning.patch` is a historical artifact of the template. It has
-no function in a spec repository — delete it.
-
----
-
-## 3. One-time setup
-
-Do this once, on a branch. It costs ten minutes and makes every subsequent
-upgrade a routine operation.
-
-### 3.1 Add the template as a remote
-
-```shell
-git remote add template https://github.com/riscv/docs-spec-template.git
-git fetch template
-```
-
-Naming it `template` (not `upstream`) matters if your repo is also a fork of
-something else.
-
-### 3.2 Establish and record your baseline
-
-Determine which template state your repo currently matches. If you know the
-release you started from, use it. If you don't, find the closest match by
-diffing tier 1 against candidate refs:
-
-```shell
-for ref in v4.0.0 v4.0.1 v4.0.2 v4.0.3 v4.0.4 template/main; do
-  n=$(git diff --name-only "$ref" -- scripts .github/workflows 2>/dev/null | wc -l)
-  printf '%-20s %s differing files\n' "$ref" "$n"
-done
-```
-
-The ref with the fewest differences is your baseline.
-
-Now record it. **This file does not exist in the template today — you are
-introducing the convention**, and it is the piece that makes upgrades repeatable
-rather than exploratory:
-
-```shell
-cat > .template-version <<'EOF'
-# Which docs-spec-template release this repository's tooling tracks.
-# Updated by the upgrade procedure in UPGRADING.md. Not a spec version --
-# spec versions are the v* git tags minted by version-bot.yml.
-template_ref: v4.0.4
-template_sha: <full SHA of that ref>
-upgraded_on: 2026-08-17
-EOF
-git add .template-version
-```
-
-Use `git rev-parse v4.0.4` to fill in the SHA. Recording the SHA as well as the
-ref matters because the template's tag namespace is shared with its own version-bot
-test tags (`vtest`, `v0.01`, `v1.0_rc1`), and tags can move; a SHA cannot.
-
-### 3.3 Pinning when there is no suitable tag
-
-The template's semver release line (`v1.0.0` → `v4.0.4`) currently lags `main`:
-substantial work — the Antora dual build, the GitHub Pages publish, the PR
-preview artifact — sits unreleased under `[Unreleased]` in `CHANGELOG.md`. If the
-feature you need is not in a tag yet, **pin to a commit SHA** on `template/main`
-and record that SHA. Do not track a moving `template/main`.
-
----
-
-## 4. The upgrade procedure
-
-### 4.1 Decide what you are taking
-
-```shell
-git fetch template
-git log --oneline <your-recorded-sha>..template/main
-git diff <your-recorded-sha>..template/main -- CHANGELOG.md
-```
-
-Read the changelog range first. The template's changelog is where breaking
-toolchain changes are described in prose; the commit list tells you what moved,
-the changelog tells you what it means for you.
-
-### 4.2 Branch
-
-```shell
-git switch -c chore/template-upgrade-<target>
-```
-
-### 4.3 Take tier 1 wholesale
-
-`git checkout` from a ref applies upstream's version of specific paths directly
-into your working tree — no merge, no conflicts, no shared history required:
-
-```shell
-TARGET=template/main   # or a tag, or a pinned SHA
-
-git checkout $TARGET -- \
-  scripts/ tests/ \
-  .github/workflows/ .github/dependabot.yml \
-  .pre-commit-config.yaml .vale.ini docker-compose.yml \
-  ANTORA.md MIGRATION.md ARC_SUBMISSION.md UPGRADING.md
-```
-
-Then review what you just staged — this is the check that catches a tier-1 file
-you had quietly customized:
-
-```shell
-git diff --cached --stat
-```
-
-### 4.4 Hand-merge tier 2
-
-For each tier 2 file, look at what changed upstream and transplant it:
-
-```shell
-git diff <your-recorded-sha>..$TARGET -- Makefile antora.yml antora-playbook.yml package.json
-```
-
-Apply upstream's changes to your copy by hand, preserving your values from the
-table in §2. Concretely, on a `Makefile` upgrade you keep your `DOCS` and
-`SPEC_SHORT` lines and take everything else.
-
-For `package.json`, take upstream's `devDependencies` versions and keep your
-`name`. Then regenerate the lockfile rather than merging it:
-
-```shell
-npm install --package-lock-only
-```
-
-### 4.5 Check the assembler
-
-```shell
-git diff <your-recorded-sha>..$TARGET -- src/
-```
-
-Apply any structural change (new preface block, changed `toc::[]` or `[index]`
-placement, new `ifndef::` default) to your own `src/<your-spec>.adoc`, keeping
-your `include::` lines. See the warning in §2.
-
-### 4.6 Update the submodule
-
-`docs-resources` upgrades on its own cadence — Dependabot proposes bumps
-independently of template releases — but pick up the template's current pointer
-during an upgrade so your build matches what upstream tested:
-
-```shell
-git checkout $TARGET -- docs-resources
-git submodule update --init --recursive
-```
-
-### 4.7 Record the new baseline
-
-Update `.template-version` with the new ref, SHA, and date. An upgrade that does
-not update this file has made the next upgrade harder than it needed to be.
-
----
-
-## 5. Verify before you merge
-
-Run all of these. They are ordered cheapest-first.
-
-```shell
-# 1. Helper-script unit tests -- catches release-info.sh regressions
-tests/release-info-test.sh          # exit 0 = all passed
-
-# 2. Version metadata resolves
-./scripts/release-info.sh version
-./scripts/release-info.sh phase "$(./scripts/release-info.sh version)"
-
-# 3. Full PDF build
-make clean && make build
-```
-
-Then confirm the **ARC filename** is correct — this is the check that matters
-most, because a wrong filename is an outright ARC rejection:
-
-```shell
-ls build/*.pdf
-```
-
-You must see `<SPEC_SHORT>-v<MAJOR>.<MINOR>-<YYYYMMDD>.pdf`. If you see a bare
-`<name>.pdf`, your `SPEC_SHORT` did not survive the `Makefile` merge.
-
-Open the PDF and check page 1 (title, version, date) and page 2 (the *Document
-State* preface with the phase notice) against `ARC_SUBMISSION.md`.
-
-Finally, the site:
-
-```shell
-npm install
-docker compose up -d kroki
-npm run preview                     # -> build/site/
-```
-
-Citations and the bibliography render as raw text in local preview — that is
-expected, not a regression. The `cite:` and `bibliography::[]` macros are
-resolved by the central playbook's ASAM extension, which is not bundled here.
-
-To reproduce exactly what CI publishes to Pages:
-
-```shell
-NO_STAMP=1 ./scripts/build-pages-site.sh    # -> build/pages-site/
-```
-
-### Post-merge checks
-
-CI on the PR exercises the rest: the PDF build, `pre-commit`, Vale, and the
-Antora content-source gate — which now attaches the rendered site as a *Rendered
-site (Antora)* artifact, so you can click through the upgraded site before
-merging.
-
-After merging, dispatch `version-bot.yml` **only when you actually intend to cut
-a release**. A template upgrade is not a specification revision; merging to
-`main` does not tag one, and it should not.
-
----
-
-## 6. What upgrades tend to break
-
-Ordered by how often they bite.
-
-1. **`SPEC_SHORT` lost in a `Makefile` merge** → non-compliant PDF filename.
-   Caught by §5's `ls build/*.pdf`.
-2. **`antora.yml` overwritten wholesale** → your component `name` reverts to
-   `spec-sample`, which silently changes the published site URL and orphans the
-   central playbook's registration. Never `git checkout` this file from upstream.
-3. **A stamped value hand-edited.** `version`, `page-revnumber`, `page-revdate`,
-   and the `page-phase*` attributes in `antora.yml` come from
-   `stamp-antora-version.sh`, which reads `release-info.sh` — the same source the
-   PDF uses. Editing them by hand desyncs the site from the PDF, which the ARC
-   Author Guide requires to match exactly. Run `make stamp-antora` instead.
-4. **`nav.adoc` numbering rules.** Chapter numbering on the published central
-   site is keyed to the **line numbers of the `xref` entries in
-   `modules/ROOT/nav.adoc`**, via `numbering_rules` in the central playbook —
-   not by anything in this repo. An upgrade that reorders your nav requires a
-   matching update in `github.com/riscv-admin/antora.riscv.org`. See *Section
-   numbering* in `ANTORA.md`.
-5. **New workflows need new repository settings.** A workflow that arrives in an
-   upgrade may need configuration that a running repo never had. Re-read the
-   *Repository Setup Checklist* in `README.adoc` after every upgrade —
-   particularly the `GHTOKEN` secret (without it, bot-opened PRs have all their
-   checks stall in `action_required`) and *Settings → Pages → Source: GitHub
-   Actions*, which a RISC-V org admin must set by hand because the org restricts
-   Pages creation and the workflow's own token is refused.
-6. **Submodule left uninitialized** after `git checkout template/main --
-   docs-resources`. `make build` auto-initializes, but `npm run preview` and
-   `build-pages-site.sh` will fail on the missing cover logo first.
-
----
-
-## 7. Rolling back
-
-Because tier 1 is applied by `git checkout` rather than merged, reverting is
-clean — there is no merge commit to unpick:
-
-```shell
-git switch main            # abandon the upgrade branch entirely
-```
-
-Or, after the fact, revert the upgrade commit:
-
-```shell
-git revert --no-commit <upgrade-commit>
-git submodule update --init --recursive
-```
-
-Then restore the previous values in `.template-version`.
-
----
-
-## 8. Alternative strategies
-
-The path-checkout approach in §4 is the recommended one: no shared history
-required, no merge conflicts, and the tiering is enforced by which paths you
-type. Two alternatives exist, both with real costs.
-
-### Unrelated-histories merge
-
-```shell
-git merge template/main --allow-unrelated-histories
-```
-
-**Gains:** real three-way merges after the first one, so tier 2 files merge
-semi-automatically and later upgrades know what you already took.
-
-**Costs:** the first merge conflicts on essentially every tier 3 file at once —
-Git has no common ancestor, so your chapters conflict with `spec-sample`'s. You
-resolve a large conflict set by hand, and any mistake silently reverts spec
-content. The template's history also becomes permanently interleaved with your
-spec's, which makes `git log` on your own content noisier forever.
-
-Worth it only if you expect to track the template closely and continuously.
-Resolve that first merge with `git checkout --ours` on all of tier 3.
-
-### Cherry-picking individual commits
-
-```shell
-git cherry-pick -x <template-commit>
-```
-
-Works when you want one specific upstream fix and nothing else. Fine for a
-targeted hotfix; unworkable as a general strategy, because template changes
-routinely span a workflow, a script, and a doc in separate commits, and picking a
-subset produces states upstream never tested.
-
----
-
-## 9. Cadence
-
-- **Per upgrade:** log it in your `CHANGELOG.md` under `[Unreleased]`, naming the
-  template ref you moved to. Your changelog is the only place a reader of your
-  repo will find out that the toolchain moved.
-- **Before any ARC submission:** upgrade first, then cut the release. ARC
-  compliance requirements change in the template; submitting from a stale
-  toolchain is the most common way to fail on format rather than content.
-- **Otherwise:** on a milestone boundary (`v0.6`, `v0.8`, `v0.9`, `v0.99`,
-  `v1.0`) is a natural rhythm — those are already governance checkpoints where
-  the `SPEC_STATE.md` PR gets maintainer attention.
-
-Do not upgrade between a `version-bot.yml` dispatch and the release build it
-triggers.
+no function in a specification repository — delete it.
+
+## B. Why this needs a procedure
+
+When you create a repository with GitHub's **Use this template**, GitHub copies
+the file tree and starts a brand-new history — a single initial commit with no
+ancestry shared with `docs-spec-template`. That is usually what you want, since
+your specification's history is its own, but it has one consequence:
+
+> Git sees your repository and the template as two unrelated projects. There is
+> no common ancestor, so there is no automatic three-way merge.
+
+Everything in this guide is about restoring enough of a relationship that
+upgrades become a routine, repeatable operation instead of a manual investigation
+every time.
+
+There is a second, less obvious problem. In your repository, **`v*` tags mean
+*specification* versions, not template versions.** `v0.62` is a milestone of your
+spec, maintained by `version-bot.yml`. Nothing in a downstream repository records
+which template version it was built from — which is why section 1.3 has you write
+that down.
+
+## C. Other approaches
+
+Section 2 uses per-path `git checkout`, which is the approach this guide supports:
+it needs no shared history, produces no merge conflicts, and the file ownership
+rules are enforced by which paths you type.
+
+Two other approaches will work, and are noted here so you recognize them if you
+see them, but neither is supported by this guide:
+
+- **`git merge template/main --allow-unrelated-histories`** gives you real
+  three-way merges on later upgrades, but the first merge conflicts on
+  essentially every specification file at once, and it interleaves the template's
+  history with your specification's permanently.
+- **`git cherry-pick -x <template-commit>`** is fine for pulling in one specific
+  upstream fix, but does not work as a general strategy, because template changes
+  routinely span a workflow, a script, and a doc in separate commits.
+
+If you use either, you are on your own for conflict resolution.
+
+## D. The other guides in this repository
+
+| Guide | Question it answers |
+| --- | --- |
+| [`MIGRATION.md`](MIGRATION.md) | "My repo predates the Antora dual build. How do I adopt the current toolchain once?" |
+| **`UPGRADING.md`** (this) | "I'm already on the toolchain. How do I keep up with the template as it changes?" |
+| [`ANTORA.md`](ANTORA.md) | "Why is the dual build designed this way?" |
+| [`ARC_SUBMISSION.md`](ARC_SUBMISSION.md) | "What does the ARC actually require?" |
 
 ---
 
 ## Questions
 
-Open an issue on `github.com/riscv/docs-spec-template` — a tier 1 file that you
-had to customize locally is a template bug, and worth reporting as one.
+Open an issue on
+[`github.com/riscv/docs-spec-template`](https://github.com/riscv/docs-spec-template/issues).
+A template-owned file that you had to customize locally is a template bug, and
+worth reporting as one.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,7 +4,7 @@
 upgraded to a later version of the template, and can keep being upgraded
 indefinitely. It is not a one-shot copy. But it is not `git pull` either — the
 mechanism has to be set up deliberately, because GitHub's "Use this template"
-deliberately severs the link.
+severs the link.
 
 **Who this is for:** maintainers of a specification repository that was created
 from `docs-spec-template` (via *Use this template* or a fork) and wants to pick

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -241,7 +241,16 @@ npm install --package-lock-only
 Your `src/<your-spec>.adoc` file is the one file that is both yours and the
 template's at the same time — it names your chapters, but everything around those
 `include::` lines is template scaffolding that changes when ARC requirements
-change. Check it on every upgrade:
+change. Check it on every upgrade, starting with a summary:
+
+```shell
+git diff --stat "$BASELINE".."$TARGET" -- src/
+```
+
+If that prints nothing, the template's assembler did not change between your two
+refs and you can move on to 2.7. If it does show changes, read them — open the
+GitHub compare URL from 2.2 and click through to `src/`, which is easier than
+reading a long AsciiDoc diff in a terminal, or read it locally:
 
 ```shell
 git diff "$BASELINE".."$TARGET" -- src/
@@ -454,8 +463,8 @@ Background material. You do not need any of it to run the procedure above.
 ## A. Which files are whose
 
 The template has a clean split between files it owns and files you own. Classify
-every path once, and every future upgrade becomes a mechanical application of
-those rules.
+every path once, and every future upgrade becomes a routine application of those
+rules rather than a fresh investigation.
 
 ### Template-owned
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -35,8 +35,9 @@ git remote add template https://github.com/riscv/docs-spec-template.git
 git fetch template
 ```
 
-Name it `template`, not `upstream`. If your repository is also a fork of
-something else, `upstream` will already be taken.
+The remote is named `template` rather than the more usual `upstream` because if
+your repository is also a fork of something else, `upstream` will already be
+taken.
 
 ### 1.2 Find your baseline
 
@@ -78,7 +79,9 @@ template version your tooling came from.
 > the template maintainers. The convention is proposed in the pull request that
 > added this guide, and only pays off if the template adopts it.
 
-First get the full commit SHA of your baseline release:
+First get the full commit SHA of the baseline you picked in 1.2. Substitute your
+own baseline here — the sample output above happened to favour `v4.0.0`, but
+yours may be any of the releases, or `template/main`:
 
 ```shell
 git rev-parse v4.0.0
@@ -104,21 +107,26 @@ Record the SHA as well as the release name. The template's tag namespace is shar
 with its own version-bot test tags (`vtest`, `v0.01`, `v1.0_rc1`), and tags can be
 moved to point at a different commit. A SHA cannot.
 
-### 1.4 If the newest release does not have what you need
+### 1.4 Optional: check whether the newest release has what you need
 
 The age of your own repository is not a problem here — you can upgrade from any
-baseline, however old. This section is about the other end: the *template's*
-newest numbered release is missing work that is already on its `main` branch.
+baseline, however old. This section is about the other end: whether the
+*template's* newest numbered release actually contains the work you are
+upgrading for.
 
-The template's numbered releases (`v1.0.0` through `v4.0.4`) currently lag behind
-its `main` branch. Several significant features — the Antora dual build, the
-GitHub Pages publish, and the pull request preview artifact — are finished and
-merged to `main` but have not been included in a numbered release yet. They are
-listed under `[Unreleased]` in the template's
-[`CHANGELOG.md`](https://github.com/riscv/docs-spec-template/blob/main/CHANGELOG.md).
+**How to tell.** Open the template's
+[`CHANGELOG.md`](https://github.com/riscv/docs-spec-template/blob/main/CHANGELOG.md)
+and read the `[Unreleased]` section at the top. Anything listed there is merged
+to `main` but is **not** in any numbered release yet. Today that includes the
+Antora dual build, the GitHub Pages publish, and the pull request preview
+artifact — the template's numbered releases (`v1.0.0` through `v4.0.4`)
+currently lag behind its `main` branch.
 
-If you need one of those features, use a commit SHA from `template/main` as your
-baseline instead of a release name:
+If nothing under `[Unreleased]` matters to you, use the newest release and go on
+to section 2.
+
+If you do need something listed there, use a commit SHA from `template/main` as
+your baseline instead of a release name:
 
 ```shell
 git rev-parse template/main
@@ -127,6 +135,10 @@ git rev-parse template/main
 Record that SHA in `.template-version` and leave `template_ref: template/main`.
 Always pin to a specific SHA. Do not upgrade against `template/main` as a moving
 target, or you will not be able to tell what changed between two upgrades.
+
+Once the template's release line catches up with `main`, this section stops
+being necessary — `[Unreleased]` will be empty and the newest release will have
+everything.
 
 ---
 
@@ -141,9 +153,10 @@ shell variable, and the rest of the commands in this section will use it:
 TARGET=template/main
 ```
 
-Use `template/main` to take the newest template code, or a release name such as
-`v4.0.4` to move to a specific numbered release. If you are pinning to a commit
-(see 1.4), use the SHA.
+`template/main` applies the latest template code, which is what you normally
+want. If you pinned to a commit SHA in 1.4, use that SHA here instead. If you
+need to land on a specific *older* template version, contact `help@riscv.org`
+rather than working it out from this guide.
 
 Set your recorded baseline the same way, taking the value of `template_sha` from
 your `.template-version` file:
@@ -152,7 +165,10 @@ your `.template-version` file:
 BASELINE=<the template_sha from .template-version>
 ```
 
-### 2.2 See what changed
+### 2.2 Optional: see what changed
+
+You can skip this section and go straight to 2.3. It is here for when you want
+to know what is arriving before you take it.
 
 ```shell
 git fetch template
@@ -161,11 +177,11 @@ git log --oneline "$BASELINE".."$TARGET"
 
 If your baseline is old, expect that list to be long — several hundred commits is
 normal, and you are not meant to read it all. It is there to show you the size of
-the jump. The changelog is the part you actually read.
+the jump.
 
 Then read the template's changelog for the same range. The commit list tells you
 what moved; the changelog tells you what it means for you, because that is where
-breaking toolchain changes are described in prose.
+breaking toolchain changes are described.
 
 The easiest way to read it is on GitHub, which renders the changelog and lets you
 browse file by file. Print the URL for your own two refs:
@@ -214,8 +230,8 @@ git diff --cached --stat
 ```
 
 If a file shows up here that you did change on purpose, stop and read that one
-diff before continuing. See the note in the Reference about local edits to
-template-owned files.
+diff before continuing. See [Template-owned](#template-owned) in the Reference
+for what to do about a local edit to a template-owned file.
 
 ### 2.5 Merge the shared files manually
 
@@ -273,30 +289,63 @@ npm install --package-lock-only
 Your `src/<your-spec>.adoc` file is the one file that is both yours and the
 template's at the same time — it names your chapters, but everything around those
 `include::` lines is template scaffolding that changes when ARC requirements
-change. Check it on every upgrade, starting with a summary:
+change.
+
+**What you are comparing, and why.** The file you diff is the template's own
+sample assembler, `src/spec-sample.adoc`, at your two refs. That tells you what
+scaffolding changed upstream. You then make the same change **by hand** in your
+own `src/<your-spec>.adoc`. You never copy `spec-sample.adoc` over your own
+file: it carries the sample specification's chapters and its own `spec_short`
+value, not yours.
+
+Start with a summary:
 
 ```shell
 git diff --stat "$BASELINE".."$TARGET" -- src/
 ```
 
 If that prints nothing, the template's assembler did not change between your two
-refs and you can move on to 2.7. If it does show changes, read them — open the
-GitHub compare URL from 2.2 and click through to `src/`, which is easier than
-reading a long AsciiDoc diff in a terminal, or write the diff to a file and open
-it in your editor:
+refs and you can move on to 2.7.
+
+If it does show changes, write the full diff to a file and open it in your
+editor, or click through to `src/` in the GitHub compare URL from 2.2, which is
+easier to read than a long AsciiDoc diff in a terminal:
 
 ```shell
 git diff "$BASELINE".."$TARGET" -- src/ > template-src.diff
 ```
 
-Apply any structural change — a new preface block, a moved `toc::[]` or `[index]`,
-a new `ifndef::` default — to your own assembler, keeping your `include::` lines.
-Never copy `src/spec-sample.adoc` over your own file.
+Then work through the diff one hunk at a time. Each hunk is one of two things:
 
-This is the most common reason a repository upgrades cleanly and then fails ARC
-review, because the compliance requirements live in exactly the file that
-ownership rules say not to touch. See
-[The one file that is both](#the-one-file-that-is-both) in the Reference.
+- **A change to an attribute, a `[preface]` block, `toc::[]`, a `list-of::`
+  macro, or `[index]`.** This is scaffolding. Make the same change, in the same
+  position, in your own `src/<your-spec>.adoc`.
+- **A change to an `include::` line.** This is the sample specification's own
+  chapters. Ignore it — your `include::` lines are yours.
+
+For example, if the diff shows the template adding an attribute default:
+
+```diff
+  ifndef::phase_display[:phase_display: {phase}]
++ ifndef::milestone_id[:milestone_id: {phase}]
+  ifndef::spec_short[:spec_short: spec-sample]
+```
+
+then add that one `ifndef::milestone_id[...]` line to your own file in the same
+place. The `spec_short` line on either side of it stays **yours** — the
+template's value is `spec-sample`, and copying it in would break your PDF
+filename.
+
+When you have finished, build the PDF (3.1) and check pages 1 and 2.
+
+> **If this step looks wrong to you, stop and ask rather than guessing.** A
+> mistake here is the most common reason a repository upgrades cleanly and then
+> fails ARC review, because the compliance requirements live in exactly the file
+> that ownership rules say not to touch. Email `help@riscv.org` or open an issue
+> on the template with `template-src.diff` and your `src/<your-spec>.adoc`
+> attached, and someone will do this merge with you. See
+> [The one file that is both](#the-one-file-that-is-both) in the Reference for
+> the background.
 
 ### 2.7 Update the submodule
 
@@ -587,9 +636,13 @@ keeping your own values from this table.
 `src/<your-spec>.adoc` is the hardest file in this list, because ownership and
 structure point in opposite directions. The file is yours — it names your
 chapters — but everything around the `include::` lines is template scaffolding
-that changes when ARC requirements change: the `[preface] == Document State`
-block, the `toc::[]` placement, the `list-of::` macros, the `[index]` position
-before the bibliography, and the `ifndef::` attribute defaults.
+that changes when ARC requirements change:
+
+- the `ifndef::` attribute defaults at the top of the file
+- the `[preface] == Document State` block
+- the `toc::[]` placement
+- the `list-of::` macros for figures, tables, and listings
+- the `[index]` position, before the bibliography
 
 > Compare `src/spec-sample.adoc` against your own assembler on every upgrade,
 > even though you never copy it over. This is the single most common source of a

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -40,7 +40,7 @@ Everything below is about restoring enough of a relationship to make upgrades
 mechanical instead of archaeological.
 
 A second, subtler problem: **in your repo, `v*` tags mean *specification*
-versions, not template versions.** `v0.62` is a milestone of your spec, minted by
+versions, not template versions.** `v0.62` is a milestone of your spec, maintained by
 `version-bot.yml`. Nothing in a downstream repo records which template version it
 was built from — so before you can upgrade, you have to establish a baseline and
 write it down. Section 3 does that.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -73,9 +73,10 @@ Now record it by creating a `.template-version` file in your repository. This fi
 makes future upgrades much easier: it is the only place that records which
 template version your tooling came from.
 
-> **Note:** `.template-version` does not exist in the template today. You are
-> introducing the convention. It is proposed in the pull request that added this
-> guide, and only pays off if the template adopts it.
+> **Note:** you are creating this file yourself — the template does not ship it,
+> and nothing reads it automatically. It is a record for your future self and for
+> the template maintainers. The convention is proposed in the pull request that
+> added this guide, and only pays off if the template adopts it.
 
 First get the full commit SHA of your baseline release:
 
@@ -88,9 +89,10 @@ Then create the file, replacing `template_ref` with your baseline from 1.2 and
 
 ```shell
 cat > .template-version <<'EOF'
-# Which docs-spec-template release this repository's tooling tracks.
-# Updated by the upgrade procedure in UPGRADING.md. Not a spec version --
-# spec versions are the v* git tags minted by version-bot.yml.
+# Records which docs-spec-template release this repository's tooling came from.
+# Nothing reads this file. You update it manually at the end of every upgrade,
+# in step 2.8. This is not a specification version -- spec versions are the
+# v* git tags created by the version-bot.yml workflow.
 template_ref: v4.0.0
 template_sha: 0000000000000000000000000000000000000000
 upgraded_on: 2026-08-17
@@ -102,7 +104,11 @@ Record the SHA as well as the release name. The template's tag namespace is shar
 with its own version-bot test tags (`vtest`, `v0.01`, `v1.0_rc1`), and tags can be
 moved to point at a different commit. A SHA cannot.
 
-### 1.4 If no release has what you need
+### 1.4 If the newest release does not have what you need
+
+The age of your own repository is not a problem here — you can upgrade from any
+baseline, however old. This section is about the other end: the *template's*
+newest numbered release is missing work that is already on its `main` branch.
 
 The template's numbered releases (`v1.0.0` through `v4.0.4`) currently lag behind
 its `main` branch. Several significant features — the Antora dual build, the
@@ -153,18 +159,24 @@ git fetch template
 git log --oneline "$BASELINE".."$TARGET"
 ```
 
+If your baseline is old, expect that list to be long — several hundred commits is
+normal, and you are not meant to read it all. It is there to show you the size of
+the jump. The changelog is the part you actually read.
+
 Then read the template's changelog for the same range. The commit list tells you
 what moved; the changelog tells you what it means for you, because that is where
 breaking toolchain changes are described in prose.
 
 The easiest way to read it is on GitHub, which renders the changelog and lets you
-browse file by file:
+browse file by file. Print the URL for your own two refs:
 
-```
-https://github.com/riscv/docs-spec-template/compare/<BASELINE>...<TARGET>
+```shell
+echo "https://github.com/riscv/docs-spec-template/compare/${BASELINE}...${TARGET#template/}"
 ```
 
-For example: <https://github.com/riscv/docs-spec-template/compare/v4.0.0...main>
+Then open what it prints **in a browser** — this is a web page, not a command.
+For example: <https://github.com/riscv/docs-spec-template/compare/v4.0.0...main>,
+which compares release `v4.0.0` against the current `main`.
 
 > **Note:** the changelog you want is the *template's* `CHANGELOG.md`, not yours.
 > A `git diff -- CHANGELOG.md` in your own repository will show nothing if your
@@ -218,16 +230,36 @@ git diff --stat "$BASELINE".."$TARGET" -- Makefile antora.yml antora-playbook.ym
 ```
 
 That gives you a summary of which files moved and by how much. To read an
-individual file's changes, either open the GitHub compare URL from 2.2 and click
-through the files, or diff one file at a time in the terminal:
+individual file's changes, open the GitHub compare URL from 2.2 and click through
+the files, or diff one file at a time locally:
 
 ```shell
 git diff "$BASELINE".."$TARGET" -- Makefile
 ```
 
-Then apply those changes to your copy, keeping the values listed under
-[Shared files](#shared-files) in the Reference. Concretely, on a `Makefile`
-upgrade you keep your `DOCS` and `SPEC_SHORT` lines and take everything else.
+If reading a diff in the terminal is awkward, write it to a file and open it in
+your editor instead:
+
+```shell
+git diff "$BASELINE".."$TARGET" -- Makefile > template-Makefile.diff
+```
+
+There is no tool for the merge itself — you edit your copy in a text editor. In
+practice:
+
+1. Get the template's version of the file somewhere you can open it:
+
+   ```shell
+   git show "$TARGET":Makefile > /tmp/Makefile.template
+   ```
+
+2. Copy across every change the diff showed, **except** the lines listed as yours
+   in the table under [Shared files](#shared-files) in the Reference.
+3. Re-run the diff against your edited copy. Whatever is left should be only the
+   lines you deliberately kept.
+
+For example, on a `Makefile` upgrade you keep your `DOCS` and `SPEC_SHORT` lines
+and take everything else.
 
 For `package.json`, take the template's `devDependencies` versions and keep your
 `name` field. Then regenerate the lockfile rather than merging it:
@@ -250,10 +282,11 @@ git diff --stat "$BASELINE".."$TARGET" -- src/
 If that prints nothing, the template's assembler did not change between your two
 refs and you can move on to 2.7. If it does show changes, read them — open the
 GitHub compare URL from 2.2 and click through to `src/`, which is easier than
-reading a long AsciiDoc diff in a terminal, or read it locally:
+reading a long AsciiDoc diff in a terminal, or write the diff to a file and open
+it in your editor:
 
 ```shell
-git diff "$BASELINE".."$TARGET" -- src/
+git diff "$BASELINE".."$TARGET" -- src/ > template-src.diff
 ```
 
 Apply any structural change — a new preface block, a moved `toc::[]` or `[index]`,
@@ -310,19 +343,39 @@ regressions:
 tests/release-info-test.sh
 ```
 
-Exit code 0 means everything passed. Next, confirm your version metadata still
-resolves:
+It takes about a second and finishes with a line like `64 passed, 0 failed`. If
+it seems to hang instead, it is blocked on a prompt rather than working — the
+test creates a throwaway git repository and commits into it, so a global git
+setting such as commit signing can stop it dead. Press Ctrl-C and re-run it as
+`bash -x tests/release-info-test.sh` to see which command it stopped on.
+
+Next, confirm your version metadata still resolves:
 
 ```shell
 ./scripts/release-info.sh version
 ./scripts/release-info.sh phase "$(./scripts/release-info.sh version)"
 ```
 
-Then run a full PDF build:
+Then run a full PDF build. This one needs Docker **running**, not merely
+installed: the `Makefile` only checks that the `docker` command exists, and if it
+does, it runs the build inside the RISC-V documentation container. Start Docker
+first.
 
 ```shell
 make clean && make build
 ```
+
+If you would rather build with a locally installed AsciiDoctor toolchain, use
+`make build-no-container` instead.
+
+If the build fails inside `asciidoctor-bibtex`, your specification has no
+bibliography. The `Makefile` loads that extension unconditionally, in `REQUIRES`,
+but the `:bibtex-file:` attribute that points it at a `.bib` lives in your
+`src/<your-spec>.adoc`. Either add that attribute and a `.bib` under
+`modules/ROOT/resources/`, or remove `--require=asciidoctor-bibtex` from
+`REQUIRES`. If you remove it, that becomes a local `Makefile` change you have to
+carry through every future merge in 2.5 — so write it down with your other
+`Makefile` values.
 
 Now check the built PDF's filename:
 
@@ -519,7 +572,7 @@ keeping your own values from this table.
 
 | File | What is yours |
 | --- | --- |
-| `Makefile` | `DOCS` (your top-level `.adoc`), `SPEC_SHORT` |
+| `Makefile` | `DOCS` (your top-level `.adoc`), `SPEC_SHORT`, and any local `REQUIRES` change (see 3.1) |
 | `antora.yml` | `name`, `title`, `asamBibliography`; `version`/`page-*` are **generated**, never edited manually |
 | `antora-playbook.yml` | `start_page: <your-component>::index.adoc` |
 | `package.json` | `name` field; devDependency **versions** are template-owned |

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -108,7 +108,7 @@ Never overwrite; always diff and transplant.
 | `.gitignore` | Usually identical; upstream adds entries as generated artifacts appear |
 | `.gitmodules` | Usually identical — verify rather than assume |
 
-### Tier 3 — Yours: never take upstream
+### Specification-specific files
 
 ```
 modules/ROOT/pages/*.adoc      your chapters


### PR DESCRIPTION
## Why

A repository created with GitHub's **Use this template** starts a fresh history with no common ancestor shared with `docs-spec-template`. Git sees the two as unrelated projects, so there is no automatic three-way merge and no obvious way to pick up later toolchain improvements — new workflows, fixed build scripts, ARC compliance changes.

`MIGRATION.md` covers adopting the toolchain **once**. This covers keeping up with it **over time**.

## What it recommends

Per-path `git checkout template/<ref> -- <paths>` rather than a merge: no shared history required, no conflicts, and the file tiering is enforced by which paths you type. The unrelated-histories merge and cherry-picking are documented as alternatives with their real costs.

Every path is sorted into three tiers:

- **Template-owned** — `scripts/`, `.github/workflows/`, reference docs. Take wholesale.
- **Shared** — `Makefile`, `antora.yml`, `antora-playbook.yml`, `package.json`. Hand-merge, keep your values.
- **Spec-owned** — `modules/ROOT/`, `SPEC_STATE.md`, `MAINTAINERS.md`. Never take upstream.

## Two things worth reviewer attention

**The `src/<spec>.adoc` exception.** It is spec-owned by ownership but template-shaped by structure — the `[preface] == Document State` block, `toc::[]` and `[index]` placement, and the `ifndef::` attribute defaults are all ARC compliance surface. It is the one file that must be diffed on every upgrade and never copied wholesale. A repo that skips it upgrades cleanly and then fails ARC on format rather than content.

**A proposed `.template-version` convention.** Downstream `v*` tags are *specification* versions minted by `version-bot.yml`, so nothing today records which template version a repo tracks. Without that baseline, every upgrade starts with archaeology. The guide is explicit that this file does not exist in the template yet — **it only pays off if the template adopts it**, so it is the main thing to agree or reject here.

The guide also notes that the semver release line (`v1.0.0` → `v4.0.4`) currently lags `main`, with the Antora dual build, Pages publish, and PR preview artifact still under `[Unreleased]`, and that the tag namespace is shared with version-bot test tags (`vtest`, `v0.01`, `v1.0_rc1`) — so it tells you to pin to a SHA rather than track a moving `main`.

## Notes

- Docs only — no build, workflow, or script changes.
- Not linked from `README.adoc` yet; happy to add a line to its `IMPORTANT` block alongside the `MIGRATION.md` / `ANTORA.md` pointers if reviewers want it here rather than in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)