### PR TITLE
fix(ci): stop development builds from consuming release versions

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -29,6 +29,8 @@ on:
         default: false
   pull_request:
   push:
+    branches:
+      - main
     tags:
       - v*
 
@@ -41,6 +43,7 @@ jobs:
     outputs:
       version: ${{ steps.set_build_version.outputs.version }}
       date: ${{ steps.set_build_version.outputs.date }}
+      releasable: ${{ steps.classify.outputs.releasable }}
 
     steps:
       # Checkout the repository
@@ -54,18 +57,27 @@ jobs:
       - name: Pull Container
         run: docker pull riscvintl/riscv-docs-base-container-image:latest
 
-      # Set VERSION for all builds (manual overrides optional).
-      # Tag pushes use the exact tag; PR builds compute next patch.
-      # Manual builds support explicit version, milestone floor, or auto behavior.
+      # Set VERSION and DATE for this build.
+      #
+      # DEVELOPMENT builds (pull_request, push to main) resolve to
+      # <latest-tag>-<sha> via release-info.sh -- byte-for-byte what a local
+      # `make` produces. They must NOT compute `next`: a preview stamped with the
+      # next release number spends a version that has not been cut, so the
+      # eventual real release ships a second, different document under the same
+      # name. (This is exactly how a PR preview and a later release both came out
+      # as v0.02.) Nothing is released from these builds -- see RELEASABLE below.
+      #
+      # RELEASE builds are a tag push, or a manual dispatch with an explicit
+      # version / milestone floor / auto-next.
       - name: Set build version
         id: set_build_version
         run: |
           set -euo pipefail
 
           # Auto-increment (`next`) refuses at a milestone gate with rc=10 (the
-          # 0.01 band before the next manual milestone is exhausted). For a
-          # preview/non-release build that is not fatal: fall back to rebuilding
-          # the latest tag rather than failing the run.
+          # 0.01 band before the next manual milestone is exhausted). That is not
+          # an error -- it means a maintainer must cut the milestone by hand -- so
+          # rebuild the latest tag rather than failing the run.
           next_or_latest() {
             local base="$1" out
             if out="$(./scripts/release-info.sh next "$base" 2>/dev/null)"; then
@@ -75,37 +87,63 @@ jobs:
             fi
           }
 
+          # Empty unless a tag pins it; filled in below.
+          date=""
+
           if [ -n "${{ github.event.inputs.release_version }}" ]; then
             version="$(./scripts/release-info.sh normalize "${{ github.event.inputs.release_version }}")"
           elif [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.event.inputs.target_phase }}" != "auto-next" ]; then
             version="$(./scripts/release-info.sh phase-floor-version "${{ github.event.inputs.target_phase }}")"
           elif [ "${{ github.ref_type }}" = "tag" ]; then
             version="$(./scripts/release-info.sh normalize "${{ github.ref_name }}")"
+            # Take the date from the TAGGED COMMIT, not from today. Rebuilding a
+            # tag must reproduce an identical PDF filename and an identical
+            # antora.yml stamp; with "today" every rebuild opened a stamp PR whose
+            # entire diff was page-revdate, and misdated the released version.
+            # Mirrors the same resolution in publish-site.yml.
+            date="$(git log -1 --format=%cs "${{ github.ref_name }}")"
           elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            latest="$(./scripts/release-info.sh latest)"
-            latest_phase="$(./scripts/release-info.sh phase "$latest")"
-            latest_floor="$(./scripts/release-info.sh phase-floor-version "$latest_phase")"
-            if [ "$latest" != "v0.0" ] && [ "$latest" != "$latest_floor" ]; then
-              # If current tag is between milestone floors, rebuild/re-release current latest tag.
-              version="$latest"
-            else
-              version="$(next_or_latest "$latest")"
-            fi
+            # Auto-next: advance to the next interim version.
+            #
+            # This used to read "if latest is between milestone floors, rebuild
+            # latest" -- an inverted test, because EVERY interim version is
+            # between floors. It pinned auto-next to re-releasing the latest tag
+            # forever, which is what produced the v0.01 -> v0.02 -> v0.01
+            # sequence. Advance unconditionally; next_or_latest falls back only
+            # at a milestone gate, which target_phase exists to cross.
+            version="$(next_or_latest "$(./scripts/release-info.sh latest)")"
           else
-            latest="$(./scripts/release-info.sh latest)"
-            version="$(next_or_latest "$latest")"
+            # Development build. release-info.sh yields <latest>-<sha>.
+            version="$(./scripts/release-info.sh version)"
           fi
-          # Resolve the build date ONCE so the PDF and the Antora version stamp
-          # share it exactly (no midnight-boundary drift between separate steps).
-          date="$(date +%Y-%m-%d)"
+
+          # Resolve the date ONCE so the PDF and the Antora version stamp share it
+          # exactly (no midnight-boundary drift between separate steps).
+          date="${date:-$(date +%Y-%m-%d)}"
+
           echo "VERSION=$version" >> "$GITHUB_ENV"
           echo "DATE=$date" >> "$GITHUB_ENV"
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "date=$date" >> "$GITHUB_OUTPUT"
 
       - name: Classify release type
+        id: classify
         run: |
           set -euo pipefail
+
+          # A development version carries a -<sha> suffix (release-info.sh
+          # get_version). It is not releasable, and every release/stamp step below
+          # is gated on this rather than on the event name -- so no trigger, now or
+          # added later, can cut a GitHub Release named after an untagged commit.
+          if [ "${VERSION#*-}" != "${VERSION}" ]; then
+            releasable=false
+            echo "$VERSION is a development version; this run publishes nothing."
+          else
+            releasable=true
+          fi
+          echo "RELEASABLE=$releasable" >> "$GITHUB_ENV"
+          echo "releasable=$releasable" >> "$GITHUB_OUTPUT"
+
           # Milestone-gate tags (v0.6, v0.8, v0.9, v0.99, v1.0) get a
           # non-prerelease GitHub Release. release-info.sh is the single source of
           # truth for which versions are milestones.
@@ -178,7 +216,7 @@ jobs:
           prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.GHTOKEN || secrets.GITHUB_TOKEN }}
-        if: github.event_name == 'push' && github.ref_type == 'tag' && env.OFFICIAL_RELEASE == 'true'
+        if: github.event_name == 'push' && github.ref_type == 'tag' && env.OFFICIAL_RELEASE == 'true' && env.RELEASABLE == 'true'
 
       # Create prerelease for non-milestone version tag pushes
       - name: Create Release (Tag Push, Pre-release)
@@ -191,7 +229,7 @@ jobs:
           prerelease: true
         env:
           GITHUB_TOKEN: ${{ secrets.GHTOKEN || secrets.GITHUB_TOKEN }}
-        if: github.event_name == 'push' && github.ref_type == 'tag' && env.OFFICIAL_RELEASE != 'true'
+        if: github.event_name == 'push' && github.ref_type == 'tag' && env.OFFICIAL_RELEASE != 'true' && env.RELEASABLE == 'true'
 
       # Create manual release for milestone versions
       - name: Create Release (Manual, Official)
@@ -204,7 +242,7 @@ jobs:
           prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.GHTOKEN || secrets.GITHUB_TOKEN }}
-        if: github.event_name == 'workflow_dispatch' && env.OFFICIAL_RELEASE == 'true'
+        if: github.event_name == 'workflow_dispatch' && env.OFFICIAL_RELEASE == 'true' && env.RELEASABLE == 'true'
 
       # Create manual prerelease for non-milestone versions
       - name: Create Release (Manual, Pre-release)
@@ -217,7 +255,7 @@ jobs:
           prerelease: true
         env:
           GITHUB_TOKEN: ${{ secrets.GHTOKEN || secrets.GITHUB_TOKEN }}
-        if: github.event_name == 'workflow_dispatch' && env.OFFICIAL_RELEASE != 'true'
+        if: github.event_name == 'workflow_dispatch' && env.OFFICIAL_RELEASE != 'true' && env.RELEASABLE == 'true'
 
   # Keep the Antora HTML site version in EXACT lockstep with the PDF this run just
   # built: stamp the SAME resolved version/date into antora.yml on main, so the
@@ -239,8 +277,9 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     if: >-
-      github.event_name != 'pull_request' &&
-      github.event.inputs.draft != 'true'
+      needs.build.outputs.releasable == 'true' &&
+      github.event.inputs.draft != 'true' &&
+      (github.ref_type == 'tag' || github.event_name == 'workflow_dispatch')
     permissions:
       contents: write
       pull-requests: write
@@ -268,12 +307,17 @@ jobs:
           echo "main antora.yml version: ${current:-<none>}; released version: $VERSION"
 
           # Monotonic guard: never stamp main backwards (e.g. when an old tag is
-          # rebuilt). Skip if main is already at a version >= this release.
-          # Compare by DECIMAL order via release-info.sh -- `sort -V` would rank
-          # v0.8 below v0.61 and stamp the site backwards.
-          if [ -n "$current" ] && [ "$current" != "~" ] && [ "$current" != "$VERSION" ]; then
-            if [ "$(./scripts/release-info.sh compare "$current" "$VERSION")" = "1" ]; then
-              echo "main is already at $current (> $VERSION); skipping stamp."
+          # rebuilt). Compare by DECIMAL order via release-info.sh -- `sort -V`
+          # would rank v0.8 below v0.61 and stamp the site backwards.
+          #
+          # Skip at >=, not just at >. At an EQUAL version the only field that can
+          # still differ is page-revdate, and a PR that moves a released version's
+          # date forward is pure churn that also misdates the release. (Rebuilding
+          # v0.01 a day later opened exactly such a PR; the tag-derived DATE in the
+          # build job closes the other half of that hole.)
+          if [ -n "$current" ] && [ "$current" != "~" ]; then
+            if [ "$(./scripts/release-info.sh compare "$current" "$VERSION")" != "-1" ]; then
+              echo "main is already at $current (>= $VERSION); skipping stamp."
               echo "changed=false" >> "$GITHUB_OUTPUT"
               exit 0
             fi

--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -1,36 +1,38 @@
 ---
 name: Create Specification Document
 
-# The workflow is triggered by pull request, version tags, and manual dispatch.
+# Cutting a release goes through version-bot.yml, which owns the version
+# arithmetic, the monotonic guard, SPEC_STATE.md and the milestone PR. It calls
+# this workflow directly rather than leaning on its tag push to trigger one, so
+# the release chain runs on the built-in GITHUB_TOKEN and needs no PAT.
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       release_version:
-        description: Override version (e.g., v0.62). Milestone floors become official releases.
-        required: false
+        description: Exact version to build and release (e.g. v0.62). Must already be tagged.
+        required: true
         type: string
-      target_phase:
-        description: Pick a milestone floor (recommended for official releases).
-        required: false
-        type: choice
-        default: auto-next
-        options:
-          - auto-next
-          - draft-and-development
-          - development-complete
-          - stabilized
-          - frozen
-          - ratification-ready
-          - ratified
       draft:
-        description: Create release as a draft?
+        description: Create the GitHub Release as a draft.
         required: false
         type: boolean
         default: false
+
+  # Preview only: builds the PDF and HTML for the current ref and publishes
+  # nothing. This used to accept release_version/target_phase/draft and cut a
+  # release of its own -- a second door that bypassed version-bot, so a milestone
+  # cut here got a tag and a release but no SPEC_STATE transition and no
+  # milestone PR. Releasing now has exactly one entry point.
+  workflow_dispatch:
+
   pull_request:
   push:
     branches:
       - main
+    # A tag pushed by hand still builds and releases. version-bot's own tag push
+    # deliberately uses GITHUB_TOKEN -- which GitHub refuses to let start a
+    # workflow run -- so this cannot double-fire alongside the workflow_call
+    # above and re-release the same version.
     tags:
       - v*
 
@@ -50,6 +52,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
+          # When version-bot calls us, build the TAGGED commit, not whatever main
+          # happens to point at by the time this job starts.
+          ref: ${{ inputs.release_version || github.ref }}
           fetch-depth: 0
           submodules: recursive
 
@@ -59,62 +64,48 @@ jobs:
 
       # Set VERSION and DATE for this build.
       #
-      # DEVELOPMENT builds (pull_request, push to main) resolve to
-      # <latest-tag>-<sha> via release-info.sh -- byte-for-byte what a local
-      # `make` produces. They must NOT compute `next`: a preview stamped with the
-      # next release number spends a version that has not been cut, so the
-      # eventual real release ships a second, different document under the same
-      # name. (This is exactly how a PR preview and a later release both came out
-      # as v0.02.) Nothing is released from these builds -- see RELEASABLE below.
+      # RELEASE builds are a version-bot call (inputs.release_version) or a
+      # hand-pushed tag. Both name an existing tag, so DATE comes from the TAGGED
+      # COMMIT rather than "today": rebuilding a tag then reproduces an identical
+      # PDF filename and an identical antora.yml stamp, instead of churning a
+      # stamp PR whose entire diff is page-revdate.
       #
-      # RELEASE builds are a tag push, or a manual dispatch with an explicit
-      # version / milestone floor / auto-next.
+      # Everything else is a DEVELOPMENT build (pull request, push to main,
+      # preview dispatch) and resolves to <latest-tag>-<sha> via release-info.sh
+      # -- byte-for-byte what a local `make` produces. Development builds must NOT
+      # compute `next`: a preview stamped with the next release number spends a
+      # version that has not been cut, so the eventual real release ships a
+      # second, different document under the same name. Nothing is released from
+      # them; see RELEASABLE below.
       - name: Set build version
         id: set_build_version
         run: |
           set -euo pipefail
 
-          # Auto-increment (`next`) refuses at a milestone gate with rc=10 (the
-          # 0.01 band before the next manual milestone is exhausted). That is not
-          # an error -- it means a maintainer must cut the milestone by hand -- so
-          # rebuild the latest tag rather than failing the run.
-          next_or_latest() {
-            local base="$1" out
-            if out="$(./scripts/release-info.sh next "$base" 2>/dev/null)"; then
-              printf '%s\n' "$out"
-            else
-              printf '%s\n' "$base"
-            fi
-          }
-
           # Empty unless a tag pins it; filled in below.
           date=""
+          tag=""
 
-          if [ -n "${{ github.event.inputs.release_version }}" ]; then
-            version="$(./scripts/release-info.sh normalize "${{ github.event.inputs.release_version }}")"
-          elif [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.event.inputs.target_phase }}" != "auto-next" ]; then
-            version="$(./scripts/release-info.sh phase-floor-version "${{ github.event.inputs.target_phase }}")"
+          if [ -n "${{ inputs.release_version }}" ]; then
+            tag="$(./scripts/release-info.sh normalize "${{ inputs.release_version }}")"
           elif [ "${{ github.ref_type }}" = "tag" ]; then
-            version="$(./scripts/release-info.sh normalize "${{ github.ref_name }}")"
-            # Take the date from the TAGGED COMMIT, not from today. Rebuilding a
-            # tag must reproduce an identical PDF filename and an identical
-            # antora.yml stamp; with "today" every rebuild opened a stamp PR whose
-            # entire diff was page-revdate, and misdated the released version.
-            # Mirrors the same resolution in publish-site.yml.
-            date="$(git log -1 --format=%cs "${{ github.ref_name }}")"
-          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            # Auto-next: advance to the next interim version.
-            #
-            # This used to read "if latest is between milestone floors, rebuild
-            # latest" -- an inverted test, because EVERY interim version is
-            # between floors. It pinned auto-next to re-releasing the latest tag
-            # forever, which is what produced the v0.01 -> v0.02 -> v0.01
-            # sequence. Advance unconditionally; next_or_latest falls back only
-            # at a milestone gate, which target_phase exists to cross.
-            version="$(next_or_latest "$(./scripts/release-info.sh latest)")"
+            tag="$(./scripts/release-info.sh normalize "${{ github.ref_name }}")"
+          fi
+
+          if [ -n "$tag" ]; then
+            version="$tag"
+            release_build=true
+            if ! date="$(git log -1 --format=%cs "$tag" 2>/dev/null)"; then
+              echo "::error::$tag is not a tag in this repository; a release build must name an existing tag."
+              exit 1
+            fi
           else
-            # Development build. release-info.sh yields <latest>-<sha>.
             version="$(./scripts/release-info.sh version)"
+            # NOT derivable from the version string: release-info.sh returns a
+            # bare vX.YY (no -<sha>) whenever HEAD happens to carry a tag, so a
+            # push to main or a preview dispatch landing on a freshly tagged
+            # commit would otherwise look releasable and re-cut that release.
+            release_build=false
           fi
 
           # Resolve the date ONCE so the PDF and the Antora version stamp share it
@@ -123,6 +114,7 @@ jobs:
 
           echo "VERSION=$version" >> "$GITHUB_ENV"
           echo "DATE=$date" >> "$GITHUB_ENV"
+          echo "RELEASE_BUILD=$release_build" >> "$GITHUB_ENV"
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "date=$date" >> "$GITHUB_OUTPUT"
 
@@ -131,15 +123,22 @@ jobs:
         run: |
           set -euo pipefail
 
-          # A development version carries a -<sha> suffix (release-info.sh
-          # get_version). It is not releasable, and every release/stamp step below
-          # is gated on this rather than on the event name -- so no trigger, now or
-          # added later, can cut a GitHub Release named after an untagged commit.
-          if [ "${VERSION#*-}" != "${VERSION}" ]; then
-            releasable=false
-            echo "$VERSION is a development version; this run publishes nothing."
-          else
+          # Two independent conditions, both required, and neither of them the
+          # event name -- under workflow_call `github.event_name` describes the
+          # CALLER, so an event test would misclassify every version-bot release.
+          #
+          #   RELEASE_BUILD  this run was asked for a specific tag
+          #   no -<sha>      the resolved version is not a development version
+          #
+          # The second alone is not enough (a preview can land on a tagged commit
+          # and resolve to a bare version); the first alone is not enough either
+          # (it is the last line of defence against ever releasing a -<sha>
+          # version). Every release step and the stamp job gate on the result.
+          if [ "$RELEASE_BUILD" = "true" ] && [ "${VERSION#*-}" = "${VERSION}" ]; then
             releasable=true
+          else
+            releasable=false
+            echo "$VERSION is a development build; this run publishes nothing."
           fi
           echo "RELEASABLE=$releasable" >> "$GITHUB_ENV"
           echo "releasable=$releasable" >> "$GITHUB_OUTPUT"
@@ -205,57 +204,36 @@ jobs:
             echo "- Retained for 30 days."
           } >> "$GITHUB_STEP_SUMMARY"
 
-      # Create official release for version tag pushes
-      - name: Create Release (Tag Push, Official)
+      # Publish the GitHub Release.
+      #
+      # There used to be four of these -- official/prerelease x tag-push/manual --
+      # because a manual dispatch could cut its own release. Releasing now has one
+      # entry point (a tag, whether version-bot pushed it or a maintainer did), so
+      # the only remaining axis is milestone vs interim. RELEASABLE, not the event
+      # name, decides whether a release happens at all.
+      - name: Create Release (Official)
         uses: softprops/action-gh-release@v2
         with:
           files: ${{ github.workspace }}/build/*.pdf
           tag_name: ${{ env.VERSION }}
           name: Release ${{ env.VERSION }}
-          draft: false
+          draft: ${{ inputs.draft || false }}
           prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.GHTOKEN || secrets.GITHUB_TOKEN }}
-        if: github.event_name == 'push' && github.ref_type == 'tag' && env.OFFICIAL_RELEASE == 'true' && env.RELEASABLE == 'true'
+        if: env.RELEASABLE == 'true' && env.OFFICIAL_RELEASE == 'true'
 
-      # Create prerelease for non-milestone version tag pushes
-      - name: Create Release (Tag Push, Pre-release)
+      - name: Create Release (Pre-release)
         uses: softprops/action-gh-release@v2
         with:
           files: ${{ github.workspace }}/build/*.pdf
           tag_name: ${{ env.VERSION }}
           name: Release ${{ env.VERSION }}
-          draft: false
+          draft: ${{ inputs.draft || false }}
           prerelease: true
         env:
           GITHUB_TOKEN: ${{ secrets.GHTOKEN || secrets.GITHUB_TOKEN }}
-        if: github.event_name == 'push' && github.ref_type == 'tag' && env.OFFICIAL_RELEASE != 'true' && env.RELEASABLE == 'true'
-
-      # Create manual release for milestone versions
-      - name: Create Release (Manual, Official)
-        uses: softprops/action-gh-release@v2
-        with:
-          files: ${{ github.workspace }}/build/*.pdf
-          tag_name: ${{ env.VERSION }}
-          name: Release ${{ env.VERSION }}
-          draft: ${{ github.event.inputs.draft }}
-          prerelease: false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GHTOKEN || secrets.GITHUB_TOKEN }}
-        if: github.event_name == 'workflow_dispatch' && env.OFFICIAL_RELEASE == 'true' && env.RELEASABLE == 'true'
-
-      # Create manual prerelease for non-milestone versions
-      - name: Create Release (Manual, Pre-release)
-        uses: softprops/action-gh-release@v2
-        with:
-          files: ${{ github.workspace }}/build/*.pdf
-          tag_name: ${{ env.VERSION }}
-          name: Release ${{ env.VERSION }}
-          draft: ${{ github.event.inputs.draft }}
-          prerelease: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GHTOKEN || secrets.GITHUB_TOKEN }}
-        if: github.event_name == 'workflow_dispatch' && env.OFFICIAL_RELEASE != 'true' && env.RELEASABLE == 'true'
+        if: env.RELEASABLE == 'true' && env.OFFICIAL_RELEASE != 'true'
 
   # Keep the Antora HTML site version in EXACT lockstep with the PDF this run just
   # built: stamp the SAME resolved version/date into antora.yml on main, so the
@@ -276,10 +254,13 @@ jobs:
   stamp-site-version:
     needs: build
     runs-on: ubuntu-latest
+    #
+    # Gated purely on the build job's own verdict: under workflow_call
+    # `github.event_name` and `github.ref_type` describe the CALLER, so testing
+    # them here would stamp on preview runs and skip real releases.
     if: >-
       needs.build.outputs.releasable == 'true' &&
-      github.event.inputs.draft != 'true' &&
-      (github.ref_type == 'tag' || github.event_name == 'workflow_dispatch')
+      inputs.draft != true
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -22,6 +22,13 @@ name: Publish site to GitHub Pages
 
 on:
   push:
+    # Publish the tip of main as the `dev` version, so the site tracks merged
+    # content instead of standing still between releases. build-pages-site.sh
+    # resolves an untagged build to <latest>-<sha> and publishes it under the
+    # short fixed label `dev` (DEV_VERSION_LABEL), so repeated merges refresh one
+    # path rather than orphaning a new /<sha>/ on every commit.
+    branches:
+      - main
     tags:
       - v*
   # Republish on demand -- e.g. after fixing content on a release, or to bring up
@@ -120,7 +127,8 @@ jobs:
       # version matches the released PDF. On a tag push the tag IS the version;
       # the date is taken from the tagged commit rather than "today" so that
       # re-running this workflow later republishes an identical site. A manual
-      # run leaves both empty, and the script falls back to release-info.sh.
+      # run -- and a push to main -- leaves both empty, and the script falls back
+      # to release-info.sh, which yields the <latest>-<sha> dev version.
       - name: Resolve release version
         id: release
         run: |

--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -21,6 +21,16 @@ name: Publish site to GitHub Pages
 # integration". Once the site exists, enablement is a no-op.
 
 on:
+  # Called by version-bot.yml immediately after a release tag is cut, so the
+  # Pages site follows a release without depending on the tag push firing an
+  # event (it cannot: version-bot tags with GITHUB_TOKEN on purpose).
+  workflow_call:
+    inputs:
+      release_version:
+        description: Release version to publish (e.g. v0.62). Must already be tagged.
+        required: true
+        type: string
+
   push:
     # Publish the tip of main as the `dev` version, so the site tracks merged
     # content instead of standing still between releases. build-pages-site.sh
@@ -85,6 +95,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
+          # When version-bot calls us, publish the TAGGED commit.
+          ref: ${{ inputs.release_version || github.ref }}
           fetch-depth: 0
           submodules: recursive
 
@@ -124,7 +136,8 @@ jobs:
           enablement: true
 
       # Version/date resolution mirrors build-pdf.yml so the published site
-      # version matches the released PDF. On a tag push the tag IS the version;
+      # version matches the released PDF. On a version-bot call or a tag push the
+      # tag IS the version;
       # the date is taken from the tagged commit rather than "today" so that
       # re-running this workflow later republishes an identical site. A manual
       # run -- and a push to main -- leaves both empty, and the script falls back
@@ -133,9 +146,16 @@ jobs:
         id: release
         run: |
           set -euo pipefail
-          if [ "${{ github.ref_type }}" = "tag" ]; then
-            version="${{ github.ref_name }}"
-            date="$(git log -1 --format=%cs "${{ github.ref_name }}")"
+          tag=""
+          if [ -n "${{ inputs.release_version }}" ]; then
+            tag="${{ inputs.release_version }}"
+          elif [ "${{ github.ref_type }}" = "tag" ]; then
+            tag="${{ github.ref_name }}"
+          fi
+
+          if [ -n "$tag" ]; then
+            version="$tag"
+            date="$(git log -1 --format=%cs "$tag")"
           else
             version=""
             date=""

--- a/.github/workflows/version-bot.yml
+++ b/.github/workflows/version-bot.yml
@@ -26,6 +26,11 @@ on:
         required: false
         type: boolean
         default: false
+      draft:
+        description: Create the GitHub Release as a draft
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -46,20 +51,27 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          # These credentials are what `git push origin "$next"` below signs the
-          # tag push with. A tag pushed by GITHUB_TOKEN cannot trigger the
-          # `push: tags: v*` run in build-pdf.yml, so the tag lands and no PDF
-          # or release is ever built. GHTOKEN makes it a real push event.
+          # Deliberately the built-in GITHUB_TOKEN, even when GHTOKEN exists.
+          #
+          # A tag pushed by GITHUB_TOKEN cannot start a `push: tags: v*` run.
+          # That used to be the problem -- the tag landed and nothing built, so
+          # the whole release chain silently required a PAT. It is now the
+          # mechanism: the release-pdf and publish-site jobs below invoke those
+          # workflows directly, and an inert tag push is what keeps them from
+          # ALSO firing on the tag and cutting the same release twice.
+          #
           # Unlike milestone-pr, this job does not use create-pull-request, so
           # persisting credentials here is safe.
-          token: ${{ secrets.GHTOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
-      # Both of this workflow's outputs -- the version tag and the milestone PR
-      # -- are inert when written by GITHUB_TOKEN, because GitHub refuses to let
-      # it start downstream runs. Checked in tag-version rather than milestone-pr
-      # so the warning appears on every run, not only at a milestone boundary.
-      # Warn rather than fail: the tag and PR are still correct, they just do
-      # not trigger anything.
+      # The release chain no longer depends on GHTOKEN: this workflow calls
+      # build-pdf.yml and publish-site.yml directly rather than hoping its tag
+      # push triggers them. What still depends on it is the CHECKS on the PRs
+      # this template's bots open (the milestone PR, the site version stamp PR):
+      # GitHub refuses to let a GITHUB_TOKEN-authored PR start workflow runs, so
+      # those checks sit in 'action_required' until a maintainer approves them.
+      # Warn rather than fail -- the tag, the release and the PRs are all still
+      # correct.
       - name: Check for bot token
         env:
           GHTOKEN: ${{ secrets.GHTOKEN }}
@@ -67,7 +79,7 @@ jobs:
           set -euo pipefail
 
           if [[ -z "$GHTOKEN" ]]; then
-            echo "::warning::GHTOKEN is not set. The version tag will not trigger the release build in build-pdf.yml, and any milestone PR's checks will sit in 'action_required' until approved by hand. See README.adoc, 'Required repository secret'."
+            echo "::warning::GHTOKEN is not set. The release itself will proceed, but checks on any PR this workflow opens will sit in 'action_required' until approved by hand. See README.adoc, 'Recommended repository secret'."
           fi
 
       - name: Compute and tag next version
@@ -168,6 +180,41 @@ jobs:
           echo "previous_phase=$prev_phase" >> "$GITHUB_OUTPUT"
           echo "next_phase=$next_phase" >> "$GITHUB_OUTPUT"
           echo "milestone_transition=$milestone_transition" >> "$GITHUB_OUTPUT"
+
+  # Build and release the PDF for the tag just cut, then publish the Antora site
+  # for it. These run as workflow_call rather than waiting on the tag push, which
+  # is inert by design (see the checkout comment above) -- so the release chain
+  # completes on the built-in GITHUB_TOKEN, with no PAT to provision in every
+  # repository seeded from this template.
+  #
+  # `if` guards the milestone-gate case: compute_next exits the job without
+  # setting next_version when the 0.01 band is exhausted, and there is then no
+  # tag to build.
+  release-pdf:
+    needs: tag-version
+    if: needs.tag-version.outputs.next_version != ''
+    uses: ./.github/workflows/build-pdf.yml
+    permissions:
+      contents: write
+      pull-requests: write
+    secrets: inherit
+    with:
+      release_version: ${{ needs.tag-version.outputs.next_version }}
+      draft: ${{ inputs.draft }}
+
+  # Sequenced after release-pdf so a failed build does not publish a site for a
+  # version that has no PDF.
+  publish-site:
+    needs: [tag-version, release-pdf]
+    if: needs.tag-version.outputs.next_version != ''
+    uses: ./.github/workflows/publish-site.yml
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    secrets: inherit
+    with:
+      release_version: ${{ needs.tag-version.outputs.next_version }}
 
   milestone-pr:
     runs-on: ubuntu-latest

--- a/README.adoc
+++ b/README.adoc
@@ -183,6 +183,18 @@ Version increment policy:
 * `v0.99`: `Ratification-Ready`
 * `v1.0`: `Ratified`
 
+=== Development builds
+
+Pull requests and pushes to `main` produce a *development* build: the PDF and HTML
+are uploaded as a 30-day workflow artifact, and pushes to `main` also republish the
+Antora site under the `dev` version. Nothing is tagged and nothing is released.
+
+Development builds are versioned `v<latest-tag>-<short-sha>`, identical to what a
+local `make` produces. They deliberately do **not** claim the next revision number:
+a preview stamped `v0.02` spends a version that has not been cut, so the real
+`v0.02` release would later ship a second, different document under the same name.
+Any version carrying a `-<sha>` suffix is refused by every release step.
+
 === Official vs prerelease policy
 
 Only these exact versions are published as official releases (`prerelease=false`):
@@ -216,7 +228,7 @@ Without it, the version bot and the release build fall back to the built-in `GIT
 
 * `release_version` to force an explicit version.
 * `target_phase` to force a milestone floor (`Developed` -> `v0.6`, `Stable` -> `v0.8`, and so on).
-* With `target_phase=auto-next` (default), manual runs use the latest existing tag if that tag is between milestone floors; otherwise they compute the next revision.
+* With `target_phase=auto-next` (default), manual runs advance to the next revision (`+0.01`). At a milestone gate, where `next` refuses, the run rebuilds the latest tag instead -- cross the gate with `target_phase`.
 
 === Manual version jumps
 

--- a/README.adoc
+++ b/README.adoc
@@ -164,10 +164,21 @@ The version bot is triggered manually, by `workflow_dispatch` on `.github/workfl
 
 1. A maintainer dispatches `.github/workflows/version-bot.yml` against `main`.
 2. The bot finds the latest `v*` tag and creates the next revision tag (`vMAJOR.MINOR`) for the current `main` commit.
-3. The new tag triggers `.github/workflows/build-pdf.yml`.
-4. The build uses the tag as `:revnumber:` and sets `:revdate:` to the build date.
+3. The bot then calls `.github/workflows/build-pdf.yml` and `.github/workflows/publish-site.yml` directly, passing the new version.
+4. The build uses the tag as `:revnumber:` and sets `:revdate:` to the tagged commit's date, so rebuilding a tag reproduces an identical PDF.
 5. `scripts/release-info.sh` derives phase (`:phase:`), display state (`:phase_display:`), warning text (`:phase_notice:`), and `:revremark:` from the version milestone.
-6. Tag-triggered builds publish GitHub Releases with the generated PDF artifacts.
+6. The build publishes a GitHub Release with the generated PDF, and opens the site version stamp PR.
+7. The site publish deploys the release to GitHub Pages.
+
+[NOTE]
+====
+The bot invokes those workflows rather than relying on its tag push to trigger
+them, and tags with the built-in `GITHUB_TOKEN` on purpose. GitHub refuses to let
+`GITHUB_TOKEN` start a workflow run, which makes the tag push inert -- so the
+release chain needs no personal access token, and cannot double-fire by
+triggering `push: tags` alongside the direct call. A tag pushed *by hand* still
+builds and releases through `push: tags: v*` as before.
+====
 
 Version increment policy:
 
@@ -211,24 +222,36 @@ All other versions are published as prereleases (`prerelease=true`).
 
 When a new tag crosses into a different phase than the previous tag, the bot opens a PR that updates `SPEC_STATE.md` for maintainer review. This PR is the checkpoint for governance/process updates required by the new phase.
 
-=== Required repository secret
+=== Recommended repository secret
 
 Set a `GHTOKEN` repository secret in every repository created from this template (Settings -> Secrets and variables -> Actions).
 
-Without it, the version bot and the release build fall back to the built-in `GITHUB_TOKEN`. GitHub refuses to let a `GITHUB_TOKEN`-authored pull request start further workflow runs, so every check on a bot-opened PR -- the PDF build, `pre-commit`, Vale, and the Antora content-source validation -- is created in the `action_required` state and waits for a maintainer to press "Approve and run". The PR itself is still correct; only its checks stall.
+`GHTOKEN` is *recommended*, not required: the release chain itself (tag -> PDF ->
+release -> Pages) runs on the built-in `GITHUB_TOKEN`.
+
+What needs it are the checks on the PRs these workflows open -- the milestone PR
+and the site version stamp PR. GitHub refuses to let a `GITHUB_TOKEN`-authored
+pull request start further workflow runs, so every check on a bot-opened PR -- the
+PDF build, `pre-commit`, Vale, and the Antora content-source validation -- is
+created in the `action_required` state and waits for a maintainer to press
+"Approve and run". The PR itself is still correct; only its checks stall.
 
 `GHTOKEN` may be either:
 
 * A fine-grained personal access token scoped to the repository with `Contents: read and write`, `Pull requests: read and write`, and `Workflows: read and write`. Simplest to set up; tied to one person's account and expires.
 * A GitHub App installation token minted per run with `actions/create-github-app-token`. Preferred for repositories with more than one maintainer, since it is not tied to an individual.
 
-=== Manual build overrides
+=== Manual builds
 
-`workflow_dispatch` for `.github/workflows/build-pdf.yml` supports:
+`workflow_dispatch` for `.github/workflows/build-pdf.yml` is a *preview* build: it
+renders the PDF and HTML for the current `main` and uploads them as a workflow
+artifact. It takes no inputs, and it neither tags nor releases anything.
 
-* `release_version` to force an explicit version.
-* `target_phase` to force a milestone floor (`Developed` -> `v0.6`, `Stable` -> `v0.8`, and so on).
-* With `target_phase=auto-next` (default), manual runs advance to the next revision (`+0.01`). At a milestone gate, where `next` refuses, the run rebuilds the latest tag instead -- cross the gate with `target_phase`.
+Releasing has exactly one entry point, `.github/workflows/version-bot.yml`. It
+previously had two -- build-pdf's dispatch could cut its own tag and release,
+which meant a milestone cut there produced a release with no `SPEC_STATE.md`
+transition and no milestone PR, and its `auto-next` handling re-released the
+latest tag on every run instead of advancing.
 
 === Manual version jumps
 


### PR DESCRIPTION
Four defects in the PDF/version automation, all reproduced in [riscv/template-testing](https://github.com/riscv/template-testing/actions).

## What was observed

| Time | Event | Version built |
|---|---|---|
| 21:55 | `workflow_dispatch` | v0.01 — released, tag created |
| 23:46 | PR #3 check | **v0.02** |
| 00:04 | PR #3 merged | *nothing built* |
| 00:07 | `workflow_dispatch` | **v0.01 again** |
| 00:08 | stamp PR #4 | date-only diff |

## Root causes

**1. Auto-next `workflow_dispatch` could never advance past the first release.**
The guard read "if latest is between milestone floors, rebuild latest" — but *every* interim version is between floors, so it was pinned to re-releasing the latest tag forever. This produced the `v0.01 -> v0.02 -> v0.01` sequence. It now advances unconditionally; `next_or_latest` still falls back at a milestone gate, which `target_phase` exists to cross.

**2. PR builds stamped the PDF with `next(latest)`** — a version never released, and possibly never released under that content. Development builds (PR and push to `main`) now resolve to `<latest>-<sha>` via `release-info.sh`, which is also exactly what a local `make` produces, so local and CI filenames finally agree.

**3. Merging a PR built nothing at all.** `build-pdf.yml` had no `push: branches` trigger, and neither did `publish-site.yml`. Both now run on `main`, giving the development build a home and letting the Antora site track merged content under the `dev` label (`build-pages-site.sh` already supported this).

**4. Rebuilding an existing tag opened a stamp PR whose entire diff was `page-revdate`,** because `DATE` was always "today" and the monotonic guard only skipped at `>`. `DATE` now comes from the tagged commit (as `publish-site.yml` already did), and the guard skips at `>=`.

## Release guard

A development version carries a `-<sha>` suffix, so `classify` derives `RELEASABLE` from it, and every release step plus the stamp job gates on that rather than on the event name — no trigger, present or future, can cut a release named after an untagged commit.

## Resulting behavior

| Trigger | Version | Release | Stamp PR | Pages |
|---|---|---|---|---|
| PR | `v0.01-sha` | — | — | — |
| Push to main | `v0.01-sha` | — | — | `dev` |
| Tag / release dispatch | `v0.02` | yes | yes | `v0.02` |

## Verification

- `actionlint` clean
- `tests/release-info-test.sh` — 64 passed, 0 failed
- Version resolution traced against a scratch repo tagged `v0.01`: tagged HEAD resolves to `v0.01`, untagged HEAD to `v0.01-d022a09`

Followed by 141, which reduces releasing to a single entry point and removes the PAT dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)