### PR TITLE
docs: correct GitHub Pages setup cause and add legacy-source trap

### DIFF
--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -14,11 +14,21 @@ name: Publish site to GitHub Pages
 # be reproduced locally.
 #
 # One-time setup in a repo seeded from this template: a repository admin must set
-# Settings -> Pages -> Source to "GitHub Actions". The configure-pages step below
-# asks for that automatically (enablement: true) and it works wherever the
-# organization permits it, but the RISC-V org restricts Pages site creation, so
-# the workflow token is refused there with "Resource not accessible by
-# integration". Once the site exists, enablement is a no-op.
+# Settings -> Pages -> Source to "GitHub Actions", ideally before the first push
+# to main -- this workflow runs on every push to main, not only on tags, so until
+# Pages exists each push leaves a failed run behind. The configure-pages step
+# below asks for that automatically (enablement: true), but GITHUB_TOKEN is
+# refused with "Resource not accessible by integration": creating a Pages site is
+# an admin-level operation the Actions app cannot perform on a repo that has
+# none, regardless of the pages: write grant below. That is a limitation of the
+# Actions token, NOT an org policy -- there is no org setting to change. Once the
+# site exists, enablement is a no-op.
+#
+# Set that source directly to "GitHub Actions". If a repo is left on "Deploy from
+# a branch" first, GitHub queues a run of its built-in pages-build-deployment
+# workflow that survives the switch and can deploy AFTER the first Actions
+# deployment, overwriting the site with the repo root -- a live 404 from a run
+# that reported success. Re-run this workflow to recover; it does not recur.
 
 on:
   # Called by version-bot.yml immediately after a release tag is cut, so the

--- a/ANTORA.md
+++ b/ANTORA.md
@@ -98,15 +98,29 @@ this is the primary HTML output; for specs that *are* consumed centrally,
 - Workflow: `.github/workflows/publish-site.yml` — runs on `v*` tag pushes and on
   manual dispatch, and deploys via `actions/deploy-pages`.
 - Build: `scripts/build-pages-site.sh` — the whole build, runnable locally.
-- Setup in a seeded repo: **one manual step**. `actions/configure-pages` is
-  configured with `enablement: true` and will turn Pages on by itself wherever
-  it is allowed to — but the RISC-V organization restricts Pages site creation,
-  so the workflow token is refused with `Resource not accessible by integration`
-  and a repository admin must set *Settings → Pages → Source* to "GitHub
-  Actions" once. Equivalent API call, with an admin token:
+- Setup in a seeded repo: **one manual step**, best done before the first push
+  to `main` — the workflow runs on every push to `main`, not only on tags, so
+  until Pages exists each push leaves a failed run behind.
+  `actions/configure-pages` is configured with `enablement: true` and will turn
+  Pages on by itself wherever it is allowed to, but the workflow's `GITHUB_TOKEN`
+  is refused with `Resource not accessible by integration`: creating a Pages site
+  is an admin-level operation that the Actions app cannot perform on a repo that
+  has none, regardless of the `pages: write` grant the job holds. This is a
+  limitation of the Actions token, **not** an organization policy — `riscv` has
+  `members_can_create_pages: true`, so there is no org setting to change and no
+  point hunting for one. A repository admin must set *Settings → Pages → Source*
+  to "GitHub Actions" once. Equivalent API call, with an admin token:
   `gh api -X POST repos/<org>/<repo>/pages -f build_type=workflow`. Once the
   site exists, `enablement: true` is a no-op and releases publish unattended.
   The job skips itself on private repos, where Pages needs Team/Enterprise.
+- Set that source **directly** to "GitHub Actions". If a repo is ever left on
+  "Deploy from a branch" first, GitHub queues a run of its built-in
+  `pages-build-deployment` workflow that survives the switch, and it can deploy
+  *after* the first Actions deployment — overwriting the site with the repository
+  root, which has no `index.html`. The symptom is a live 404 from a
+  `publish-site.yml` run that reported success; check the `github-pages`
+  deployment list for a `pages-build-deployment` entry newer than yours. Re-run
+  `publish-site.yml` once the stray build has finished; it does not recur.
 
 ### How the playbook is derived
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -513,13 +513,21 @@ else depends on it.
       /modules/ROOT/images/risc-v_logo.svg
       ```
 - [ ] **Have a repository admin enable Pages once**: *Settings → Pages → Build
-      and deployment → Source: GitHub Actions*. The workflow asks for this
-      automatically (`enablement: true`), but the RISC-V organization restricts
-      Pages site creation, so the workflow's token is refused with
-      `Resource not accessible by integration`. Equivalent API call:
+      and deployment → Source: GitHub Actions*, before the first push to `main`
+      — the workflow runs on every push to `main`, not only on tags. The workflow
+      asks for this automatically (`enablement: true`), but the built-in
+      `GITHUB_TOKEN` is refused with `Resource not accessible by integration`:
+      that is a limitation of the Actions token, **not** an organization policy,
+      so there is no org-level setting to change. Equivalent API call, with an
+      admin token:
       ```bash
       gh api -X POST repos/<org>/<repo>/pages -f build_type=workflow
       ```
+      Set the source *directly* to "GitHub Actions". If it is set to "Deploy from
+      a branch" first, GitHub queues a build of its built-in
+      `pages-build-deployment` workflow that can land after your first Actions
+      deployment and overwrite the site with the repo root — a live 404 from a
+      run that reported success. Re-run `publish-site.yml` to recover.
       Pages also needs a public repo unless your org is on Team/Enterprise; the
       job skips itself on private repos rather than failing your release.
 - [ ] Verify locally before pushing (needs Kroki, as in Step 10):

--- a/README.adoc
+++ b/README.adoc
@@ -38,9 +38,12 @@ When instantiating a new repository from this template, perform these one-time s
    *(Alternatively, configure a repository secret named `GHTOKEN` with a Personal Access Token).*
 2. **Initialize Submodules**:
    Run `git submodule update --init --recursive` in your local workspace.
-3. **Enable GitHub Pages** (only if you want the published HTML site):
+3. **Enable GitHub Pages**:
    Go to *Settings* -> *Pages* -> *Build and deployment* -> Set *Source* to *GitHub Actions*.
-   The publish workflow attempts this automatically, but the RISC-V organization restricts Pages site creation, so the workflow's built-in token cannot do it — a repository admin must do it once by hand. After that, every release publishes without further intervention.
+   Do this **before the first push to `main`**. `publish-site.yml` runs on every push to `main`, not only on release tags, so until Pages is enabled each push leaves a failed run behind.
+   The workflow asks for this automatically (`enablement: true`), but the built-in `GITHUB_TOKEN` cannot create a Pages site — it is refused with `Resource not accessible by integration`. That is a limitation of the Actions token itself, *not* an organization policy: there is no org-level setting to change, and a repository admin must do it once by hand. After that, every release publishes without further intervention.
+   Set the source **directly** to *GitHub Actions*. If it is set to *Deploy from a branch* first, GitHub queues a run of its own built-in `pages-build-deployment` workflow, and that run can finish *after* your first Actions deployment and overwrite the site with the repository root — a live 404 from a workflow that reported success. Recover by re-running `publish-site.yml` once the stray build has finished; it does not recur.
+   Pages needs a public repository unless your organization is on Team/Enterprise; the job skips itself on private repos rather than failing the release.
 
 == Building the Document
 
@@ -135,7 +138,7 @@ To check bibliography output, build with `make` (the PDF/HTML use the `asciidoct
 
 Every `v*` release tag also publishes the specification as an HTML site on this repository's own GitHub Pages site, alongside the release PDF, via `.github/workflows/publish-site.yml`. The site lands at `https://<org>.github.io/<repo>/`.
 
-This needs the one-time *Enable GitHub Pages* step from the <<Repository Setup Checklist>> above. The workflow tries to enable Pages itself, but the RISC-V organization restricts Pages site creation, so its token is refused (`Resource not accessible by integration`) and a repository admin has to set the source to *GitHub Actions* once by hand. Everything after that is automatic.
+This needs the one-time *Enable GitHub Pages* step from the <<Repository Setup Checklist>> above. The workflow tries to enable Pages itself, but its `GITHUB_TOKEN` is refused (`Resource not accessible by integration`) — a limitation of the Actions token rather than an organization policy — so a repository admin has to set the source to *GitHub Actions* once by hand. Everything after that is automatic.
 
 The site version is stamped from the same source as the PDF, so the two always match. A build with no release tag to name it — such as the first manual run in a new repository — publishes under `/spec-sample/dev/` rather than a long `vX.YY-<sha>-<date>` path, which keeps the URL stable and the site navigation readable; the exact commit is still shown on the cover page.
 


### PR DESCRIPTION
Signed-off-by: Bill Traynor <wmat@riscv.org>
